### PR TITLE
Sync service improvement and translation text label updated

### DIFF
--- a/console/src/lib/i18n/en/nav.ts
+++ b/console/src/lib/i18n/en/nav.ts
@@ -5,7 +5,7 @@ export const nav: Record<string, string> = {
   "nav.system": "System",
   "nav.homeDashboard": "Home Dashboard",
   "nav.deployment": "Execution History",
-  "nav.jobsTemplates": "Deployment & Stack",
+  "nav.jobsTemplates": "Stack & Deployment",
   "nav.hosts": "Hosts & Groups",
   "nav.roles": "Roles",
   "nav.playbooks": "Playbooks",

--- a/console/src/lib/i18n/en/pages.ts
+++ b/console/src/lib/i18n/en/pages.ts
@@ -45,7 +45,7 @@ export const pages: Record<string, string> = {
   "page.playbooksRoles.subtitle": "Manage reusable Ansible playbooks and roles from one place.",
 
   // Infrastructure - templates
-  "page.templates.title": "Jobs & Templates",
+  "page.templates.title": "Stack Deployment & Templates",
   "page.templates.subtitle": "Reusable Build & Deployment Jobs — parameterized template runs with lifecycle actions (Init, Validate, Plan, Apply).",
 
   // Infrastructure - vaults & secrets

--- a/console/src/lib/i18n/km/nav.ts
+++ b/console/src/lib/i18n/km/nav.ts
@@ -5,7 +5,7 @@ export const nav: Record<string, string> = {
   "nav.system": "ប្រព័ន្ធ",
   "nav.homeDashboard": "ផ្ទាំងគ្រប់គ្រងដើម",
   "nav.deployment": "ប្រវត្តិការប្រតិបត្តិការ",
-  "nav.jobsTemplates": "Deployment & Stack",
+  "nav.jobsTemplates": "Stack & Deployment",
   "nav.hosts": "ម៉ាស៊ីន និងក្រុម",
   "nav.roles": "តួនាទី",
   "nav.playbooks": "Playbooks",

--- a/console/src/lib/i18n/km/pages.ts
+++ b/console/src/lib/i18n/km/pages.ts
@@ -34,7 +34,7 @@ export const pages: Record<string, string> = {
   "page.playbooksRoles.subtitle": "គ្រប់គ្រង Playbooks និង Roles របស់ Ansible ដែលអាចប្រើឡើងវិញក្នុងទីតាំងតែមួយ។",
 
 
-  "page.templates.title": "Jobs & Templates",
+  "page.templates.title": "Stack Deployment & Templates",
   "page.templates.subtitle": "Build & Deployment Jobs ដែលអាចប្រើឡើងវិញ — កែសម្រួលបានតាម template ជាមួយសកម្មភាព (Init, Validate, Plan, Apply)។",
 
   "page.vaults.title": "Vaults & Secrets",

--- a/console/src/lib/i18n/ko/nav.ts
+++ b/console/src/lib/i18n/ko/nav.ts
@@ -5,7 +5,7 @@ export const nav: Record<string, string> = {
   "nav.system": "시스템",
   "nav.homeDashboard": "홈 대시보드",
   "nav.deployment": "실행 이력",
-  "nav.jobsTemplates": "Deployment & Stack",
+  "nav.jobsTemplates": "스택 및 배포",
   "nav.hosts": "호스트 및 그룹",
   "nav.roles": "역할",
   "nav.playbooks": "플레이북",

--- a/console/src/lib/i18n/ko/pages.ts
+++ b/console/src/lib/i18n/ko/pages.ts
@@ -34,7 +34,7 @@ export const pages: Record<string, string> = {
   "page.playbooksRoles.subtitle": "재사용 가능한 Ansible 플레이북과 역할을 한 곳에서 관리하세요.",
 
 
-  "page.templates.title": "작업 & 템플릿",
+  "page.templates.title": "스택 배포 및 템플릿",
   "page.templates.subtitle": "재사용 가능한 Build & Deployment 작업 — 라이프사이클 액션(Init, Validate, Plan, Apply)이 있는 매개변수화된 템플릿 실행.",
 
   "page.vaults.title": "볼트 & 시크릿",

--- a/console/src/routes/infrastructure/job.tsx
+++ b/console/src/routes/infrastructure/job.tsx
@@ -261,7 +261,7 @@ function JobDetail() {
     <div className="space-y-6">
       <Breadcrumbs items={[
         { label: "Infrastructure" },
-        { label: "Jobs & Templates", to: "/infrastructure/templates" },
+        { label: "Stack Deployment & Templates", to: "/infrastructure/templates" },
         { label: inst?.filename || "Job" },
       ]} />
 

--- a/console/src/routes/infrastructure/templates.tsx
+++ b/console/src/routes/infrastructure/templates.tsx
@@ -182,7 +182,7 @@ function TemplatesPage() {
 
   return (
     <div className="space-y-4">
-      <Breadcrumbs items={[{ label: "Infrastructure" }, { label: "Jobs & Templates" }]} />
+      <Breadcrumbs items={[{ label: "Infrastructure" }, { label: "Stack Deployment & Templates" }]} />
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <div>
           <h1 className="text-2xl font-semibold">{t("page.templates.title")}</h1>

--- a/server/services/source_sync_service.py
+++ b/server/services/source_sync_service.py
@@ -1653,9 +1653,27 @@ class SourceSyncService:
     #   <projects_dir>/<project_id>/stacks/
     # and mirrors the Git repo (optionally narrowed by `git.subdir`).
     # ------------------------------------------------------------------
-    def _mirror_copy(self, src: Path, dst: Path):
-        """Mirror src directory tree into dst, excluding any .git folder."""
+    GIT_EXCLUDE_DIRS = {'.git', '.terraform', '.terragrunt-cache'}
+    GIT_EXCLUDE_FILE_SUFFIXES = ('.tfstate', '.tfstate.backup', '.tfplan')
+
+    @classmethod
+    def _is_git_excluded(cls, name: str, is_dir: bool) -> bool:
+        if name in cls.GIT_EXCLUDE_DIRS:
+            return True
+        if not is_dir and name.endswith(cls.GIT_EXCLUDE_FILE_SUFFIXES):
+            return True
+        return False
+
+    def _mirror_copy(self, src: Path, dst: Path, exclude_heavy: bool = False):
+        """Mirror src directory tree into dst, excluding .git (and, when
+        exclude_heavy, OpenTofu caches/state that cannot be committed)."""
         dst.mkdir(parents=True, exist_ok=True)
+
+        def skip(name: str, is_dir: bool) -> bool:
+            if name == '.git':
+                return True
+            return exclude_heavy and self._is_git_excluded(name, is_dir)
+
         # Wipe existing contents (except .git, if any — shouldn't be present in storage)
         for item in list(dst.iterdir()):
             if item.name == '.git':
@@ -1666,12 +1684,21 @@ class SourceSyncService:
                 item.unlink()
         if not src.exists():
             return
+
+        ignore = None
+        if exclude_heavy:
+            def ignore(dirpath, names):  # noqa: F811
+                return [
+                    n for n in names
+                    if self._is_git_excluded(n, (Path(dirpath) / n).is_dir())
+                ]
+
         for item in src.iterdir():
-            if item.name == '.git':
+            if skip(item.name, item.is_dir()):
                 continue
             target = dst / item.name
             if item.is_dir():
-                shutil.copytree(item, target, dirs_exist_ok=True)
+                shutil.copytree(item, target, dirs_exist_ok=True, ignore=ignore)
             else:
                 shutil.copy2(item, target)
 
@@ -1756,8 +1783,20 @@ class SourceSyncService:
             git_target = (git_root / subdir) if subdir else git_root
             git_target.mkdir(parents=True, exist_ok=True)
 
-            logger.info(f"[STACKS PUSH] Mirror {storage_path} -> {git_target}")
-            self._mirror_copy(storage_path, git_target)
+            logger.info(f"[STACKS PUSH] Mirror {storage_path} -> {git_target} (excluding .terraform/state)")
+            self._mirror_copy(storage_path, git_target, exclude_heavy=True)
+
+            # Belt and braces: make sure the repo ignores provider caches/state
+            try:
+                gitignore = git_root / '.gitignore'
+                needed = ['.terraform/', '.terragrunt-cache/', '*.tfstate', '*.tfstate.backup', '*.tfplan']
+                existing = gitignore.read_text().splitlines() if gitignore.exists() else []
+                missing = [p for p in needed if p not in existing]
+                if missing:
+                    lines = existing + ([''] if existing and existing[-1].strip() else []) + missing
+                    gitignore.write_text('\n'.join(lines).strip() + '\n')
+            except Exception as e:
+                logger.warning(f"[STACKS PUSH] Could not update .gitignore: {e}")
 
             try:
                 git_env = self.git_source_manager._get_auth_env(project_id, auth_secret_id, repo_url)
@@ -1780,6 +1819,12 @@ class SourceSyncService:
                     if cur != ref:
                         subprocess.run(['git', 'checkout', ref], capture_output=True, text=True)
 
+                upstream = subprocess.run(['git', 'rev-parse', '--verify', f'origin/{ref}'], capture_output=True, text=True)
+                if upstream.returncode == 0:
+                    ahead = subprocess.run(['git', 'rev-list', '--count', f'origin/{ref}..HEAD'], capture_output=True, text=True)
+                    if (ahead.stdout or '0').strip() not in ('', '0'):
+                        subprocess.run(['git', 'reset', '--soft', f'origin/{ref}'], capture_output=True, text=True)
+
                 subprocess.run(['git', 'add', '-A'], check=True, capture_output=True, text=True)
                 status = subprocess.run(['git', 'status', '--porcelain'], capture_output=True, text=True)
                 if status.stdout.strip():
@@ -1794,7 +1839,15 @@ class SourceSyncService:
                 else:
                     p = subprocess.run(['git', 'push', 'origin', ref], capture_output=True, text=True, env=git_env)
                 if p.returncode != 0:
-                    return False, SyncErrorCode.SYNC_IO_ERROR.value, f"git push failed: {p.stderr.strip()}", None
+                    err = (p.stderr or '').strip()
+                    if 'exceed' in err and 'limit' in err:
+                        err = (
+                            "git push rejected: the remote refuses files over its blob size limit. "
+                            "This is usually a .terraform provider cache or a large state file already present "
+                            "in the remote branch history. OpenSible no longer pushes those, but existing history "
+                            "must be cleaned on the remote (or Git LFS enabled).\n\n" + err
+                        )
+                    return False, SyncErrorCode.SYNC_IO_ERROR.value, f"git push failed: {err}", None
 
                 rev = subprocess.run(['git', 'rev-parse', 'HEAD'], check=True, capture_output=True, text=True).stdout.strip()
                 return True, None, None, rev


### PR DESCRIPTION
- Fixed Git push failures for cloud stack projects caused by oversized OpenTofu artifacts.
- Push mirroring now excludes `.terraform/`, `.terragrunt-cache`, `*.tfstate`, `*.tfstate.backup`, and `*.tfplan`.
- The target repository `.gitignore` is updated automatically with those patterns on push.
- Local-only commits are squashed onto `origin/<ref>` before recommitting, so an unpushed oversized blob no longer blocks every subsequent push.
- Added a clearer error message when the remote rejects a push because of a blob size limit