### PR TITLE
Implement Policy-as-Code Gates and Plan Diff UX for Cloud Stack Provisioning

### DIFF
--- a/console/src/components/cloud/PlanDiff.tsx
+++ b/console/src/components/cloud/PlanDiff.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+import { ChevronRight, FilePlus2, FileMinus2, FileDiff, RefreshCcwDot, Eye, CheckCircle2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { parseTofuPlan, ACTION_META, type PlanChangeAction, type PlanResource } from "@/lib/tofu-plan";
+import { cn } from "@/lib/utils";
+
+const TONE_CLASS: Record<string, string> = {
+  create: "text-emerald-600 dark:text-emerald-400",
+  update: "text-amber-600 dark:text-amber-400",
+  destroy: "text-red-600 dark:text-red-400",
+  neutral: "text-[var(--color-muted-foreground)]",
+};
+
+const ACTION_ICON: Record<PlanChangeAction, any> = {
+  create: FilePlus2,
+  update: FileDiff,
+  replace: RefreshCcwDot,
+  destroy: FileMinus2,
+  read: Eye,
+  drift: RefreshCcwDot,
+};
+
+function ResourceRow({ res }: { res: PlanResource }) {
+  const [open, setOpen] = useState(false);
+  const meta = ACTION_META[res.action];
+  const Icon = ACTION_ICON[res.action];
+  const tone = TONE_CLASS[meta.tone] ?? TONE_CLASS.neutral;
+  return (
+    <div className="border-b border-[var(--color-border)] last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-[var(--color-accent)]/40"
+      >
+        <ChevronRight
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 text-[var(--color-muted-foreground)] transition-transform",
+            open && "rotate-90",
+            res.attrs.length === 0 && "opacity-0"
+          )}
+        />
+        <Icon className={cn("h-4 w-4 shrink-0", tone)} />
+        <span className={cn("font-mono text-xs font-semibold w-4 shrink-0", tone)}>{meta.sign}</span>
+        <span className="font-mono text-xs truncate flex-1">{res.address}</span>
+        <span className={cn("text-[10px] uppercase tracking-wide shrink-0", tone)}>{meta.label}</span>
+      </button>
+      {open && res.attrs.length > 0 && (
+        <div className="bg-[var(--color-muted)]/40 px-4 py-2 font-mono text-[11px] leading-5 overflow-x-auto">
+          {res.attrs.map((a, i) => (
+            <div key={`${a.name}-${i}`} className="whitespace-pre">
+              <span
+                className={cn(
+                  a.op === "+" ? TONE_CLASS.create : a.op === "-" ? TONE_CLASS.destroy : TONE_CLASS.update
+                )}
+              >
+                {a.op}
+              </span>{" "}
+              <span className="text-[var(--color-foreground)]">{a.name}</span>
+              {" = "}
+              {a.op === "~" ? (
+                <>
+                  <span className={TONE_CLASS.destroy}>{a.before ?? "(known after apply)"}</span>
+                  <span className="text-[var(--color-muted-foreground)]"> → </span>
+                  <span className={TONE_CLASS.create}>{a.after ?? "(known after apply)"}</span>
+                </>
+              ) : (
+                <span className="text-[var(--color-muted-foreground)]">{a.after ?? a.before}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ value, label, tone }: { value: number; label: string; tone: string }) {
+  return (
+    <div className="flex flex-col items-center rounded-md border border-[var(--color-border)] px-4 py-2 min-w-[92px]">
+      <span className={cn("text-xl font-semibold tabular-nums", tone)}>{value}</span>
+      <span className="text-[10px] uppercase tracking-wide text-[var(--color-muted-foreground)]">{label}</span>
+    </div>
+  );
+}
+
+export function PlanDiff({
+  log,
+  action,
+  className,
+}: {
+  log: string;
+  action?: string;
+  className?: string;
+}) {
+  const parsed = useMemo(() => parseTofuPlan(log), [log]);
+  const [filter, setFilter] = useState<"all" | PlanChangeAction>("all");
+
+  if (!parsed.hasPlan) return null;
+
+  const counts = parsed.resources.reduce<Record<string, number>>((acc, r) => {
+    acc[r.action] = (acc[r.action] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const shown = filter === "all" ? parsed.resources : parsed.resources.filter((r) => r.action === filter);
+  const s = parsed.summary;
+  const isDrift = action === "drift" || action === "refresh";
+
+  return (
+    <Card className={className}>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <FileDiff className="h-4 w-4" />
+          {isDrift ? "Drift diff" : s?.applied ? "Apply result" : "Plan diff"}
+        </CardTitle>
+        {s?.noChanges && (
+          <Badge variant="success" className="text-[10px] gap-1">
+            <CheckCircle2 className="h-3 w-3" /> No changes
+          </Badge>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {s && !s.noChanges && (
+          <div className="flex flex-wrap gap-2">
+            <Stat value={s.add} label={s.applied ? "added" : "to add"} tone={TONE_CLASS.create!} />
+            <Stat value={s.change} label={s.applied ? "changed" : "to change"} tone={TONE_CLASS.update!} />
+            <Stat value={s.destroy} label={s.applied ? "destroyed" : "to destroy"} tone={TONE_CLASS.destroy!} />
+          </div>
+        )}
+
+        {parsed.resources.length > 0 && (
+          <>
+            <div className="flex flex-wrap gap-1.5">
+              <button
+                type="button"
+                onClick={() => setFilter("all")}
+                className={cn(
+                  "text-[11px] rounded-full border border-[var(--color-border)] px-2.5 py-1",
+                  filter === "all" ? "bg-[var(--color-accent)]" : "hover:bg-[var(--color-accent)]/50"
+                )}
+              >
+                All ({parsed.resources.length})
+              </button>
+              {(Object.keys(counts) as PlanChangeAction[]).map((a) => (
+                <button
+                  key={a}
+                  type="button"
+                  onClick={() => setFilter(a)}
+                  className={cn(
+                    "text-[11px] rounded-full border border-[var(--color-border)] px-2.5 py-1",
+                    filter === a ? "bg-[var(--color-accent)]" : "hover:bg-[var(--color-accent)]/50",
+                    TONE_CLASS[ACTION_META[a].tone]
+                  )}
+                >
+                  {ACTION_META[a].label} ({counts[a]})
+                </button>
+              ))}
+            </div>
+
+            <div className="border border-[var(--color-border)] rounded-md overflow-hidden">
+              {shown.map((r) => (
+                <ResourceRow key={r.address + r.action} res={r} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {parsed.outputs.length > 0 && (
+          <div>
+            <div className="text-xs font-medium mb-1">Output changes</div>
+            <div className="rounded-md bg-[var(--color-muted)]/40 px-3 py-2 font-mono text-[11px] leading-5">
+              {parsed.outputs.map((o, i) => (
+                <div key={`${o.name}-${i}`} className="whitespace-pre">
+                  <span
+                    className={cn(
+                      o.op === "+" ? TONE_CLASS.create : o.op === "-" ? TONE_CLASS.destroy : TONE_CLASS.update
+                    )}
+                  >
+                    {o.op}
+                  </span>{" "}
+                  {o.name} = {o.op === "~" ? `${o.before} → ${o.after}` : (o.after ?? o.before)}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <p className="text-[11px] text-[var(--color-muted-foreground)]">
+          Parsed from the run log. The full OpenTofu output remains below as the source of truth.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/console/src/components/cloud/PolicyGateCard.tsx
+++ b/console/src/components/cloud/PolicyGateCard.tsx
@@ -1,0 +1,407 @@
+/**
+ * Policy-as-code gate panel for a single Cloud stack.
+ */
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { ShieldCheck, ShieldAlert, ShieldX, Save, Info } from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { api } from "@/lib/api";
+
+type Severity = "warn" | "deny";
+
+type Rule = {
+  enabled: boolean;
+  severity: Severity;
+  max_destroy?: number;
+  types?: string[];
+  keys?: string[];
+  ports?: number[];
+  limit?: number;
+};
+
+type PolicyConfig = {
+  mode: "warn" | "enforce";
+  rules: Record<string, Rule>;
+};
+
+type Violation = {
+  rule: string;
+  severity: Severity;
+  address?: string;
+  type?: string;
+  message: string;
+};
+
+type LastResult = {
+  run_id?: string;
+  action?: string;
+  checked_at?: number | null;
+  verdict?: "pass" | "warn" | "fail" | string;
+  denies?: number;
+  warns?: number;
+  violations?: Violation[];
+} | null;
+
+type PolicyResp = {
+  enabled: boolean;
+  policy: PolicyConfig;
+  last_result: LastResult;
+};
+
+const RULE_META: Record<string, { title: string; help: string }> = {
+  deny_destroy: {
+    title: "Block destructive changes",
+    help: "Fires when the plan would delete resources beyond the allowed count.",
+  },
+  denied_resource_types: {
+    title: "Denied resource types",
+    help: "Fires when the plan creates or updates a resource type on your block list.",
+  },
+  require_tags: {
+    title: "Required tags",
+    help: "Fires when a created or updated taggable resource is missing a required tag key.",
+  },
+  deny_public_ingress: {
+    title: "No public ingress on sensitive ports",
+    help: "Fires when a firewall or security-group rule opens a listed port to 0.0.0.0/0 or ::/0.",
+  },
+  max_created: {
+    title: "Maximum resources created",
+    help: "Fires when a single plan creates more resources than the limit — a blast-radius guard.",
+  },
+};
+
+const RULE_ORDER = [
+  "deny_public_ingress",
+  "deny_destroy",
+  "require_tags",
+  "denied_resource_types",
+  "max_created",
+];
+
+function Toggle({
+  checked,
+  onChange,
+  disabled,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50"
+      style={{ background: checked ? "var(--color-primary)" : "var(--color-muted)" }}
+    >
+      <span
+        className="inline-block h-5 w-5 rounded-full bg-[var(--color-background)] shadow transition-transform"
+        style={{ transform: checked ? "translateX(22px)" : "translateX(2px)" }}
+      />
+    </button>
+  );
+}
+
+function listToText(v?: Array<string | number>) {
+  return (v || []).join(", ");
+}
+
+function textToList(s: string) {
+  return s
+    .split(",")
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+export function PolicyGateCard({ stackId }: { stackId: string }) {
+  const url = `/api/cloud/stacks/${encodeURIComponent(stackId)}/policy`;
+  const q = useQuery({
+    queryKey: ["cloud", "stack-policy", stackId],
+    queryFn: () => api<PolicyResp>("GET", url),
+    refetchInterval: 20000,
+  });
+
+  const [draft, setDraft] = useState<PolicyConfig | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (q.data?.policy && !dirty) setDraft(q.data.policy);
+  }, [q.data, dirty]);
+
+  const enabled = !!q.data?.enabled;
+  const last = q.data?.last_result || null;
+
+  const saveMut = useMutation({
+    mutationFn: (body: { enabled?: boolean; policy?: PolicyConfig }) =>
+      api<PolicyResp>("PUT", url, body),
+    onSuccess: (_d, vars) => {
+      setDirty(false);
+      q.refetch();
+      toast.success(
+        vars.enabled === undefined
+          ? "Policy rules saved"
+          : vars.enabled
+          ? "Policy gate enabled"
+          : "Policy gate disabled",
+      );
+    },
+    onError: (e: any) => toast.error(e?.message || "Failed to update the policy gate"),
+  });
+
+  const patchRule = (id: string, patch: Partial<Rule>) => {
+    if (!draft) return;
+    const current = draft.rules[id];
+    if (!current) return;
+    setDirty(true);
+    setDraft({ ...draft, rules: { ...draft.rules, [id]: { ...current, ...patch } } });
+  };
+
+  const verdictBadge = (() => {
+    switch (last?.verdict) {
+      case "pass":
+        return { label: "Last check passed", variant: "success" as const, Icon: ShieldCheck };
+      case "warn":
+        return { label: `${last?.warns || 0} warning(s)`, variant: "warning" as const, Icon: ShieldAlert };
+      case "fail":
+        return { label: `${last?.denies || 0} violation(s)`, variant: "destructive" as const, Icon: ShieldX };
+      default:
+        return { label: "Not evaluated yet", variant: "default" as const, Icon: ShieldCheck };
+    }
+  })();
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div>
+          <CardTitle className="text-base flex items-center gap-2">
+            <verdictBadge.Icon className="h-4 w-4" /> Policy gate
+            {enabled ? (
+              <Badge variant={verdictBadge.variant}>{verdictBadge.label}</Badge>
+            ) : (
+              <Badge variant="default">Disabled</Badge>
+            )}
+          </CardTitle>
+          <p className="text-xs text-[var(--color-muted-foreground)] mt-1 max-w-2xl">
+            Evaluates every plan, apply and destroy against your rules before the change lands. Rules run
+            inside the worker against the JSON plan — no extra service, agent or policy engine to operate.
+            Disabled by default; when off, runs behave exactly as before.
+          </p>
+        </div>
+        <Toggle
+          checked={enabled}
+          disabled={saveMut.isPending}
+          label="Toggle policy gate"
+          onChange={(v) => saveMut.mutate({ enabled: v })}
+        />
+      </CardHeader>
+
+      <CardContent>
+        {!enabled ? (
+          <div className="text-sm text-[var(--color-muted-foreground)]">
+            The policy gate is turned off for this stack. Enable it to check plans against guardrails such as
+            "no public SSH", "no unexpected destroys" and "required tags".
+          </div>
+        ) : !draft ? (
+          <div className="text-sm text-[var(--color-muted-foreground)]">Loading rules…</div>
+        ) : (
+          <div className="space-y-5">
+            {/* Mode */}
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-sm font-medium">Mode</span>
+              <div className="w-56">
+                <Select
+                  value={draft.mode}
+                  onChange={(v) => {
+                    setDirty(true);
+                    setDraft({ ...draft, mode: v as PolicyConfig["mode"] });
+                  }}
+                  options={[
+                    { value: "warn", label: "Warn", description: "Report violations, never block a run" },
+                    { value: "enforce", label: "Enforce", description: "Block the run when a deny rule fires" },
+                  ]}
+                />
+              </div>
+              <span className="text-xs text-[var(--color-muted-foreground)] flex items-center gap-1">
+                <Info className="h-3.5 w-3.5" />
+                {draft.mode === "enforce"
+                  ? "Apply and destroy are blocked when a deny-severity rule fires."
+                  : "Violations are reported in the run log only."}
+              </span>
+            </div>
+
+            {/* Rules */}
+            <div className="space-y-3">
+              {RULE_ORDER.filter((id) => draft.rules[id]).map((id) => {
+                const rule = draft.rules[id]!;
+                const meta = RULE_META[id]!;
+                return (
+                  <div
+                    key={id}
+                    className="rounded-xl border border-[var(--color-border)] p-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+                  >
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium flex items-center gap-2">
+                        {meta.title}
+                        {rule.enabled && (
+                          <Badge variant={rule.severity === "deny" ? "destructive" : "warning"}>
+                            {rule.severity === "deny" ? "Deny" : "Warn"}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-[var(--color-muted-foreground)] mt-0.5">{meta.help}</p>
+
+                      {rule.enabled && (
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          {id === "deny_destroy" && (
+                            <label className="text-xs flex items-center gap-2">
+                              Allowed destroys
+                              <Input
+                                type="number"
+                                min={0}
+                                className="w-24"
+                                value={rule.max_destroy ?? 0}
+                                onChange={(e) =>
+                                  patchRule(id, { max_destroy: Math.max(0, Number(e.target.value) || 0) })
+                                }
+                              />
+                            </label>
+                          )}
+                          {id === "max_created" && (
+                            <label className="text-xs flex items-center gap-2">
+                              Limit
+                              <Input
+                                type="number"
+                                min={1}
+                                className="w-24"
+                                value={rule.limit ?? 50}
+                                onChange={(e) => patchRule(id, { limit: Math.max(1, Number(e.target.value) || 1) })}
+                              />
+                            </label>
+                          )}
+                          {id === "deny_public_ingress" && (
+                            <label className="text-xs flex items-center gap-2 w-full sm:w-auto">
+                              Ports
+                              <Input
+                                className="w-full sm:w-64"
+                                placeholder="22, 3389"
+                                value={listToText(rule.ports)}
+                                onChange={(e) =>
+                                  patchRule(id, {
+                                    ports: textToList(e.target.value)
+                                      .map((p) => Number(p))
+                                      .filter((n) => Number.isFinite(n) && n > 0 && n < 65536),
+                                  })
+                                }
+                              />
+                            </label>
+                          )}
+                          {id === "require_tags" && (
+                            <label className="text-xs flex items-center gap-2 w-full sm:w-auto">
+                              Tag keys
+                              <Input
+                                className="w-full sm:w-72"
+                                placeholder="environment, owner"
+                                value={listToText(rule.keys)}
+                                onChange={(e) => patchRule(id, { keys: textToList(e.target.value) })}
+                              />
+                            </label>
+                          )}
+                          {id === "denied_resource_types" && (
+                            <label className="text-xs flex items-center gap-2 w-full sm:w-auto">
+                              Types
+                              <Input
+                                className="w-full sm:w-80"
+                                placeholder="aws_iam_user, hcloud_server"
+                                value={listToText(rule.types)}
+                                onChange={(e) => patchRule(id, { types: textToList(e.target.value) })}
+                              />
+                            </label>
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-3 shrink-0">
+                      {rule.enabled && (
+                        <div className="w-28">
+                          <Select
+                            value={rule.severity}
+                            onChange={(v) => patchRule(id, { severity: v as Severity })}
+                            options={[
+                              { value: "warn", label: "Warn" },
+                              { value: "deny", label: "Deny" },
+                            ]}
+                          />
+                        </div>
+                      )}
+                      <Toggle
+                        checked={rule.enabled}
+                        label={`Toggle ${meta.title}`}
+                        onChange={(v) => patchRule(id, { enabled: v })}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button
+                size="sm"
+                disabled={!dirty || saveMut.isPending}
+                onClick={() => saveMut.mutate({ policy: draft })}
+              >
+                <Save className="h-4 w-4 mr-1.5" /> Save rules
+              </Button>
+              {dirty && (
+                <span className="text-xs text-[var(--color-muted-foreground)]">Unsaved changes</span>
+              )}
+            </div>
+
+            {/* Last verdict */}
+            {last && (
+              <div className="rounded-xl border border-[var(--color-border)] p-3">
+                <div className="text-sm font-medium flex items-center gap-2">
+                  Last evaluation
+                  <Badge variant={verdictBadge.variant}>{verdictBadge.label}</Badge>
+                  <span className="text-xs font-normal text-[var(--color-muted-foreground)]">
+                    from {last.action || "run"}
+                  </span>
+                </div>
+                {last.violations && last.violations.length > 0 ? (
+                  <ul className="mt-2 space-y-1">
+                    {last.violations.slice(0, 25).map((v, i) => (
+                      <li key={i} className="text-xs flex flex-wrap items-baseline gap-2">
+                        <Badge variant={v.severity === "deny" ? "destructive" : "warning"}>
+                          {v.severity === "deny" ? "DENY" : "WARN"}
+                        </Badge>
+                        <code className="font-mono">{v.address || "plan"}</code>
+                        <span className="text-[var(--color-muted-foreground)]">{v.message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-[var(--color-muted-foreground)] mt-1">
+                    No violations in the last evaluated run.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/console/src/components/cloud/VmInventoryDialog.tsx
+++ b/console/src/components/cloud/VmInventoryDialog.tsx
@@ -43,7 +43,7 @@ export function VmInventoryDialog({ stackId, onClose }: { stackId: string; onClo
           <div className="flex items-center gap-3">
             <Boxes className="h-5 w-5" />
             <div>
-              <h2 className="text-lg font-semibold">VM Inventory · {stackId}</h2>
+              <h2 className="text-lg font-semibold">Inventory Resources · {stackId}</h2>
               <p className="text-xs text-[var(--color-muted-foreground)]">
                 {data?.generated_at
                   ? `Last refreshed: ${new Date(data.generated_at * 1000).toLocaleString()}`

--- a/console/src/lib/i18n/en/pages.ts
+++ b/console/src/lib/i18n/en/pages.ts
@@ -186,7 +186,7 @@ export const pages: Record<string, string> = {
   "summary.loadingRun": "Loading run…",
   "summary.loadingLog": "Loading log…",
   "summary.exit": "exit",
-  "summary.vmInventory": "VM Inventory",
+  "summary.vmInventory": "Inventory Resources",
   "summary.vmCount": "{count} VMs",
   "summary.vmCountOne": "{count} VM",
   "summary.loadingInventory": "Loading inventory…",

--- a/console/src/lib/i18n/km/pages.ts
+++ b/console/src/lib/i18n/km/pages.ts
@@ -168,7 +168,7 @@ export const pages: Record<string, string> = {
   "summary.loadingRun": "កំពុងផ្ទុកដំណើរការ…",
   "summary.loadingLog": "កំពុងផ្ទុកកំណត់ហេតុ…",
   "summary.exit": "លទ្ធផលចាកចេញ",
-  "summary.vmInventory": "បញ្ជី VM",
+  "summary.vmInventory": "បញ្ជីធនធាន",
   "summary.vmCount": "{count} VM",
   "summary.vmCountOne": "{count} VM",
   "summary.loadingInventory": "កំពុងផ្ទុកបញ្ជី…",

--- a/console/src/lib/i18n/ko/pages.ts
+++ b/console/src/lib/i18n/ko/pages.ts
@@ -168,7 +168,7 @@ export const pages: Record<string, string> = {
   "summary.loadingRun": "실행 불러오는 중…",
   "summary.loadingLog": "로그 불러오는 중…",
   "summary.exit": "종료 코드",
-  "summary.vmInventory": "VM 인벤토리",
+  "summary.vmInventory": "리소스 인벤토리",
   "summary.vmCount": "{count}개 VM",
   "summary.vmCountOne": "{count}개 VM",
   "summary.loadingInventory": "인벤토리 불러오는 중…",

--- a/console/src/lib/tofu-plan.ts
+++ b/console/src/lib/tofu-plan.ts
@@ -1,0 +1,188 @@
+export type PlanChangeAction =
+  | "create"
+  | "update"
+  | "replace"
+  | "destroy"
+  | "read"
+  | "drift";
+
+export type PlanAttrChange = {
+  op: "+" | "-" | "~";
+  name: string;
+  before?: string;
+  after?: string;
+};
+
+export type PlanResource = {
+  address: string;
+  type: string;
+  name: string;
+  action: PlanChangeAction;
+  attrs: PlanAttrChange[];
+};
+
+export type PlanSummary = {
+  add: number;
+  change: number;
+  destroy: number;
+  /** true when tofu explicitly reported "No changes." */
+  noChanges: boolean;
+  /** true when the log came from an apply (counts are final, not planned) */
+  applied: boolean;
+};
+
+export type ParsedPlan = {
+  resources: PlanResource[];
+  summary: PlanSummary | null;
+  outputs: PlanAttrChange[];
+  /** Whether anything plan-like was found at all. */
+  hasPlan: boolean;
+};
+
+const RESOURCE_HEADER =
+  /^\s*#\s+(.+?)\s+(will be created|will be destroyed|will be updated in-place|must be replaced|will be replaced|will be read during apply|has been deleted|has changed|will no longer be managed|has been removed)/;
+
+function actionFor(phrase: string): PlanChangeAction {
+  if (phrase.includes("created")) return "create";
+  if (phrase.includes("destroyed") || phrase.includes("no longer be managed") || phrase.includes("removed"))
+    return "destroy";
+  if (phrase.includes("replaced")) return "replace";
+  if (phrase.includes("read during apply")) return "read";
+  if (phrase.includes("has been deleted") || phrase.includes("has changed")) return "drift";
+  return "update";
+}
+
+function splitAddress(address: string): { type: string; name: string } {
+  // Strip module prefixes and any resource(...) wrapper quoting.
+  const clean = address.replace(/^resource\s+/, "").replace(/"/g, "");
+  const parts = clean.split(".");
+  if (parts.length >= 2) {
+    return { type: parts[parts.length - 2] ?? clean, name: parts[parts.length - 1] ?? clean };
+  }
+  return { type: clean, name: clean };
+}
+
+const ATTR_LINE = /^\s*([+~-])\s+([A-Za-z0-9_."\-\[\]]+)\s*=\s*(.*)$/;
+
+function parseAttr(line: string): PlanAttrChange | null {
+  const m = ATTR_LINE.exec(line);
+  if (!m) return null;
+  const op = (m[1] ?? "+") as "+" | "-" | "~";
+  const name = (m[2] ?? "").replace(/"/g, "");
+  const rhs = (m[3] ?? "").trim();
+  if (op === "~") {
+    const arrow = rhs.split("->");
+    if (arrow.length >= 2) {
+      return {
+        op,
+        name,
+        before: cleanValue(arrow[0] ?? ""),
+        after: cleanValue(arrow.slice(1).join("->")),
+      };
+    }
+    return { op, name, after: cleanValue(rhs) };
+  }
+  if (op === "-") return { op, name, before: cleanValue(rhs.replace(/\s*->\s*null$/, "")) };
+  return { op, name, after: cleanValue(rhs) };
+}
+
+function cleanValue(v: string): string {
+  return v
+    .trim()
+    .replace(/,$/, "")
+    .replace(/\s*#\s*forces replacement$/, "")
+    .trim();
+}
+
+export function parseTofuPlan(log: string): ParsedPlan {
+  const empty: ParsedPlan = { resources: [], summary: null, outputs: [], hasPlan: false };
+  if (!log) return empty;
+
+  const lines = log.split("\n");
+  const resources: PlanResource[] = [];
+  const outputs: PlanAttrChange[] = [];
+  let current: PlanResource | null = null;
+  let inOutputs = false;
+
+  for (const raw of lines) {
+    const line = raw.replace(/\r$/, "");
+    const header = RESOURCE_HEADER.exec(line);
+    if (header) {
+      const address = (header[1] ?? "").trim();
+      const { type, name } = splitAddress(address);
+      current = { address, type, name, action: actionFor(header[2] ?? ""), attrs: [] };
+      resources.push(current);
+      inOutputs = false;
+      continue;
+    }
+
+    if (/^Changes to Outputs:/.test(line)) {
+      current = null;
+      inOutputs = true;
+      continue;
+    }
+
+    if (current) {
+      if (/^\s*}\s*$/.test(line)) {
+        current = null;
+        continue;
+      }
+      if (current.attrs.length < 40) {
+        const attr = parseAttr(line);
+        if (attr) current.attrs.push(attr);
+      }
+      continue;
+    }
+
+    if (inOutputs) {
+      if (line.trim() === "") {
+        inOutputs = false;
+        continue;
+      }
+      const attr = parseAttr(line);
+      if (attr) outputs.push(attr);
+    }
+  }
+
+  let summary: PlanSummary | null = null;
+  const planMatch = /Plan:\s*(\d+)\s+to add,\s*(\d+)\s+to change,\s*(\d+)\s+to destroy/.exec(log);
+  const applyMatch = /Resources:\s*(\d+)\s+added,\s*(\d+)\s+changed,\s*(\d+)\s+destroyed/.exec(log);
+  if (applyMatch) {
+    summary = {
+      add: Number(applyMatch[1] ?? 0),
+      change: Number(applyMatch[2] ?? 0),
+      destroy: Number(applyMatch[3] ?? 0),
+      noChanges: false,
+      applied: true,
+    };
+  } else if (planMatch) {
+    summary = {
+      add: Number(planMatch[1] ?? 0),
+      change: Number(planMatch[2] ?? 0),
+      destroy: Number(planMatch[3] ?? 0),
+      noChanges: false,
+      applied: false,
+    };
+  } else if (/No changes\./.test(log)) {
+    summary = { add: 0, change: 0, destroy: 0, noChanges: true, applied: false };
+  }
+
+  return {
+    resources,
+    summary,
+    outputs,
+    hasPlan: resources.length > 0 || summary !== null,
+  };
+}
+
+export const ACTION_META: Record<
+  PlanChangeAction,
+  { label: string; sign: string; tone: "create" | "update" | "destroy" | "neutral" }
+> = {
+  create: { label: "create", sign: "+", tone: "create" },
+  update: { label: "update", sign: "~", tone: "update" },
+  replace: { label: "replace", sign: "±", tone: "destroy" },
+  destroy: { label: "destroy", sign: "-", tone: "destroy" },
+  read: { label: "read", sign: "<", tone: "neutral" },
+  drift: { label: "drifted", sign: "!", tone: "update" },
+};

--- a/console/src/routes/cloud/cost.tsx
+++ b/console/src/routes/cloud/cost.tsx
@@ -858,7 +858,7 @@ function ReportsTab() {
               )}
               {!list.isLoading && filtered.length === 0 && (
                 <tr><td colSpan={9} className="px-4 py-8 text-center text-muted-foreground">
-                  No cost reports yet. Run <strong>Apply</strong> on a stack and open <strong>VM Inventory</strong> — a timestamped report will appear here automatically.
+                  No cost reports yet. Run <strong>Apply</strong> on a stack and open <strong>Inventory Resources</strong> — a timestamped report will appear here automatically.
                 </td></tr>
               )}
               {filtered.map((r) => (

--- a/console/src/routes/cloud/stacks/$stackId.tsx
+++ b/console/src/routes/cloud/stacks/$stackId.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft, CheckCircle2, Download, Search, Rocket, Bomb, RefreshCcw, RefreshCw, Clock,
-  GitBranch, GitPullRequestArrow, Edit, Trash2, KeyRound, AlertTriangle, Boxes, Github, Radar,
+  GitBranch, GitPullRequestArrow, Edit, Trash2, KeyRound, AlertTriangle, Boxes, Github, Radar, Settings, X,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Breadcrumbs } from "@/components/app-shell/Breadcrumbs";
@@ -13,6 +13,7 @@ import { Badge, statusToVariant } from "@/components/ui/badge";
 import { VmInventoryDialog } from "@/components/cloud/VmInventoryDialog";
 import { RunFlowGraph } from "@/components/cloud/RunFlowGraph";
 import { PlanDiff } from "@/components/cloud/PlanDiff";
+import { PolicyGateCard } from "@/components/cloud/PolicyGateCard";
 import { ProvisioningLogDialog } from "@/routes/cloud/summary";
 import { api } from "@/lib/api";
 import { qk } from "@/lib/query";
@@ -97,6 +98,8 @@ function StackDetail() {
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showInventory, setShowInventory] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [flowLog, setFlowLog] = useState("");
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -354,8 +357,12 @@ function StackDetail() {
           </Button>
         )}
         <Button variant="outline" onClick={() => setShowInventory(true)}>
-          <Boxes className="h-4 w-4" /> VM Inventory
+          <Boxes className="h-4 w-4" /> Inventory Resources
         </Button>
+        <Button variant="outline" onClick={() => setSettingsOpen(true)}>
+          <Settings className="h-4 w-4" /> Settings
+        </Button>
+
         {runStatus.status && (
           <div className="ml-auto text-xs flex items-center gap-2">
             <Badge variant={statusToVariant(runStatus.status)}>{runStatus.status}</Badge>
@@ -404,7 +411,26 @@ function StackDetail() {
         </div>
       )}
 
+      {settingsOpen && (
+      <div className="fixed inset-0 z-50 flex justify-end bg-black/50" onClick={() => setSettingsOpen(false)}>
+      <div
+        className="h-full w-full max-w-xl bg-[var(--color-card)] border-l border-[var(--color-border)] shadow-2xl overflow-y-auto animate-in slide-in-from-right duration-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-[var(--color-border)] sticky top-0 bg-[var(--color-card)] z-10">
+          <div>
+            <h3 className="text-base font-semibold flex items-center gap-2">
+              <Settings className="h-4 w-4" /> Settings
+            </h3>
+            <p className="text-xs text-[var(--color-muted-foreground)] mt-0.5 font-mono">{stackId}</p>
+          </div>
+          <button onClick={() => setSettingsOpen(false)} className="p-1 rounded hover:bg-[var(--color-muted)]" aria-label="Close settings">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="p-4 space-y-4">
       <Card>
+
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div>
             <CardTitle className="text-base flex items-center gap-2">
@@ -474,6 +500,15 @@ function StackDetail() {
           )}
         </CardContent>
       </Card>
+
+      <PolicyGateCard stackId={stackId} />
+        </div>
+      </div>
+      </div>
+      )}
+
+
+
 
 
 

--- a/console/src/routes/cloud/stacks/$stackId.tsx
+++ b/console/src/routes/cloud/stacks/$stackId.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge, statusToVariant } from "@/components/ui/badge";
 import { VmInventoryDialog } from "@/components/cloud/VmInventoryDialog";
 import { RunFlowGraph } from "@/components/cloud/RunFlowGraph";
+import { PlanDiff } from "@/components/cloud/PlanDiff";
 import { ProvisioningLogDialog } from "@/routes/cloud/summary";
 import { api } from "@/lib/api";
 import { qk } from "@/lib/query";
@@ -477,11 +478,14 @@ function StackDetail() {
 
 
       {(lastAction || running) && (
-        <RunFlowGraph
-          action={running || lastAction || "plan"}
-          log={flowLog}
-          status={runStatus.status}
-        />
+        <>
+          <RunFlowGraph
+            action={running || lastAction || "plan"}
+            log={flowLog}
+            status={runStatus.status}
+          />
+          <PlanDiff log={flowLog} action={running || lastAction || undefined} />
+        </>
       )}
 
       <Card>

--- a/console/src/routes/cloud/summary.tsx
+++ b/console/src/routes/cloud/summary.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge, statusToVariant } from "@/components/ui/badge";
 import { LogViewer } from "@/components/cloud/LogViewer";
+import { PlanDiff } from "@/components/cloud/PlanDiff";
 import { RunFlowGraph } from "@/components/cloud/RunFlowGraph";
 import { api } from "@/lib/api";
 import { qk } from "@/lib/query";
@@ -318,6 +319,7 @@ export function ProvisioningLogDialog({
           {detail?.action && (
             <RunFlowGraph action={detail.action} log={detail.log || ""} status={detail.status} />
           )}
+          <PlanDiff log={detail?.log || ""} action={detail?.action} />
           <InventorySection stack={stack} />
           <LogViewer text={detail?.log || t("summary.loadingLog")} className="max-h-[60vh]" />
         </div>

--- a/server/services/cloud_policy.py
+++ b/server/services/cloud_policy.py
@@ -1,0 +1,185 @@
+"""
+Policy-as-code gate for Cloud Provisioning stacks (opt-in per stack).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from flask import jsonify, request
+
+POLICY_RULE_TYPES = {
+    "deny_destroy",
+    "denied_resource_types",
+    "require_tags",
+    "deny_public_ingress",
+    "max_created",
+}
+
+SEVERITIES = ("warn", "deny")
+
+
+def default_policy() -> Dict[str, Any]:
+    """Conservative starting point: everything off except the two cheap,
+    universally-agreed guardrails, and `mode` starts in warn."""
+    return {
+        "mode": "warn",  # warn | enforce
+        "rules": {
+            "deny_destroy": {"enabled": False, "severity": "deny", "max_destroy": 0},
+            "denied_resource_types": {"enabled": False, "severity": "deny", "types": []},
+            "require_tags": {"enabled": False, "severity": "warn", "keys": ["environment", "owner"]},
+            "deny_public_ingress": {"enabled": True, "severity": "deny", "ports": [22, 3389]},
+            "max_created": {"enabled": False, "severity": "warn", "limit": 50},
+        },
+    }
+
+
+def policy_enabled_from_meta(meta: Dict[str, Any]) -> bool:
+    """Policy gate is OFF unless the stack explicitly opted in."""
+    return bool((meta or {}).get("policy_enabled") is True)
+
+
+def policy_config_from_meta(meta: Dict[str, Any]) -> Dict[str, Any]:
+    stored = (meta or {}).get("policy_rules")
+    cfg = default_policy()
+    if isinstance(stored, dict):
+        if stored.get("mode") in ("warn", "enforce"):
+            cfg["mode"] = stored["mode"]
+        for rid, rule in (stored.get("rules") or {}).items():
+            if rid in cfg["rules"] and isinstance(rule, dict):
+                cfg["rules"][rid].update({k: v for k, v in rule.items() if k != "id"})
+    return cfg
+
+
+def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
+    cfg = default_policy()
+    mode = (body.get("mode") or "").strip().lower()
+    if mode in ("warn", "enforce"):
+        cfg["mode"] = mode
+    rules = body.get("rules") or {}
+    if not isinstance(rules, dict):
+        return cfg
+    for rid, incoming in rules.items():
+        if rid not in POLICY_RULE_TYPES or not isinstance(incoming, dict):
+            continue
+        target = cfg["rules"][rid]
+        target["enabled"] = bool(incoming.get("enabled"))
+        sev = (incoming.get("severity") or "").strip().lower()
+        if sev in SEVERITIES:
+            target["severity"] = sev
+        if rid == "deny_destroy":
+            try:
+                target["max_destroy"] = max(0, int(incoming.get("max_destroy", 0)))
+            except (TypeError, ValueError):
+                pass
+        elif rid == "denied_resource_types":
+            types = incoming.get("types")
+            if isinstance(types, list):
+                target["types"] = [str(t).strip() for t in types if str(t).strip()][:100]
+        elif rid == "require_tags":
+            keys = incoming.get("keys")
+            if isinstance(keys, list):
+                target["keys"] = [str(k).strip() for k in keys if str(k).strip()][:50]
+        elif rid == "deny_public_ingress":
+            ports = incoming.get("ports")
+            if isinstance(ports, list):
+                clean = []
+                for p in ports[:100]:
+                    try:
+                        n = int(p)
+                    except (TypeError, ValueError):
+                        continue
+                    if 0 < n < 65536:
+                        clean.append(n)
+                target["ports"] = clean
+        elif rid == "max_created":
+            try:
+                target["limit"] = max(1, int(incoming.get("limit", 50)))
+            except (TypeError, ValueError):
+                pass
+    return cfg
+
+
+def latest_policy_result(ex_dir: Path, name: str) -> Optional[Dict[str, Any]]:
+    """Most recent policy verdict recorded by a worker for this stack."""
+    if not ex_dir or not ex_dir.exists():
+        return None
+    files = sorted(ex_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for f in files[:300]:
+        try:
+            exe = json.loads(f.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        rp = exe.get("runParams") or {}
+        if rp.get("execution_type") != "TOFU_RUN" or rp.get("stack_name") != name:
+            continue
+        res = exe.get("result") or exe.get("stats") or {}
+        pol = res.get("policy") if isinstance(res, dict) else None
+        if not isinstance(pol, dict):
+            continue
+        return {
+            "run_id": exe.get("id"),
+            "action": rp.get("tofu_action"),
+            "checked_at": int(exe.get("finishedAt") or exe.get("startedAt") or 0) or None,
+            "verdict": pol.get("verdict"),
+            "denies": pol.get("denies"),
+            "warns": pol.get("warns"),
+            "violations": pol.get("violations") or [],
+        }
+    return None
+
+
+def register_policy_routes(
+    bp,
+    *,
+    require_auth,
+    get_project_id,
+    valid_name,
+    stack_dir,
+    read_meta,
+    save_meta,
+    project_executions_dir,
+):
+    """Attach GET/PUT /stacks/<name>/policy to the cloud blueprint."""
+
+    def _payload(pid, name):
+        meta = read_meta(pid, name)
+        return {
+            "enabled": policy_enabled_from_meta(meta),
+            "policy": policy_config_from_meta(meta),
+            "last_result": latest_policy_result(project_executions_dir(pid), name),
+        }
+
+    @bp.route("/stacks/<name>/policy", methods=["GET"])
+    @require_auth
+    def policy_get(name):
+        pid = get_project_id()
+        if not valid_name(name) or not stack_dir(pid, name).exists():
+            return jsonify({"error": "Not found"}), 404
+        return jsonify(_payload(pid, name))
+
+    @bp.route("/stacks/<name>/policy", methods=["PUT"])
+    @require_auth
+    def policy_set(name):
+        """Enable/disable and configure the policy gate for one stack."""
+        pid = get_project_id()
+        if not valid_name(name) or not stack_dir(pid, name).exists():
+            return jsonify({"error": "Not found"}), 404
+        body = request.get_json(silent=True) or {}
+        patch: Dict[str, Any] = {}
+        if "enabled" in body:
+            enabled = body.get("enabled")
+            if isinstance(enabled, str):
+                enabled = enabled.strip().lower() in ("1", "true", "yes", "on")
+            if not isinstance(enabled, bool):
+                return jsonify({"error": "'enabled' must be a boolean."}), 400
+            patch["policy_enabled"] = enabled
+        if "policy" in body and isinstance(body.get("policy"), dict):
+            patch["policy_rules"] = sanitize_policy(body["policy"])
+        if not patch:
+            return jsonify({"error": "Nothing to update."}), 400
+        save_meta(pid, name, **patch)
+        return jsonify({"ok": True, **_payload(pid, name)})
+
+    return bp

--- a/server/services/cloud_provisioning.py
+++ b/server/services/cloud_provisioning.py
@@ -584,6 +584,7 @@ def _list_stacks(project_id: Optional[str]) -> List[Dict[str, Any]]:
             "drift_enabled": meta.get("drift_enabled") is True,
             "drift_status": (_drift_status(project_id, entry.name)["status"]
                              if meta.get("drift_enabled") is True else "disabled"),
+            "policy_enabled": meta.get("policy_enabled") is True,
         })
     return out
 
@@ -892,6 +893,10 @@ def _create_execution(project_id: Optional[str], stack: str, action: str, worker
         "secret_keys": list(_secret_keys_for(provider)),
         "env": {"TF_IN_AUTOMATION": "1"},
     }
+    # Policy-as-code gate: only shipped to the worker when the stack opted in,
+    # so stacks with the gate off pay exactly zero extra cost.
+    if _policy_enabled(project_id, stack) and action in ("plan", "apply", "destroy"):
+        run_params["policy"] = _policy_config(project_id, stack)
     if not worker_id:
         # Tofu needs the backend-local IaC tree at stack_dir; auto-pin to a
         # co-located worker (tagged 'local' or 'default') so multi-worker
@@ -1060,6 +1065,45 @@ def drift_set(name):
         return jsonify({"error": "Body must include boolean 'enabled'."}), 400
     _save_meta(pid, name, drift_enabled=enabled)
     return jsonify({"ok": True, **_drift_status(pid, name)})
+
+
+# ---------------------------------------------------------------------------
+# Policy-as-code gate (opt-in per stack, disabled by default)
+# ---------------------------------------------------------------------------
+
+try:
+    from services.cloud_policy import (
+        policy_config_from_meta as _policy_config_from_meta,
+        policy_enabled_from_meta as _policy_enabled_from_meta,
+        register_policy_routes as _register_policy_routes,
+    )
+except ImportError:  # pragma: no cover
+    from .cloud_policy import (  # type: ignore
+        policy_config_from_meta as _policy_config_from_meta,
+        policy_enabled_from_meta as _policy_enabled_from_meta,
+        register_policy_routes as _register_policy_routes,
+    )
+
+
+def _policy_enabled(project_id: Optional[str], name: str) -> bool:
+    return _policy_enabled_from_meta(_read_meta(project_id, name))
+
+
+def _policy_config(project_id: Optional[str], name: str) -> Dict[str, Any]:
+    return _policy_config_from_meta(_read_meta(project_id, name))
+
+
+_register_policy_routes(
+    bp,
+    require_auth=require_auth,
+    get_project_id=lambda: _get_project_id(),
+    valid_name=lambda n: _valid_name(n),
+    stack_dir=lambda pid, n: _stack_dir(pid, n),
+    read_meta=lambda pid, n: _read_meta(pid, n),
+    save_meta=lambda pid, n, **kw: _save_meta(pid, n, **kw),
+    project_executions_dir=lambda pid: _project_executions_dir(pid),
+)
+
 
 
 

--- a/worker/internal/execute/ policy.go
+++ b/worker/internal/execute/ policy.go
@@ -1,0 +1,431 @@
+// Policy-as-code gate for Cloud Provisioning stacks.
+package execute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type policyRule struct {
+	Enabled    bool     `json:"enabled"`
+	Severity   string   `json:"severity"`
+	MaxDestroy int      `json:"max_destroy"`
+	Types      []string `json:"types"`
+	Keys       []string `json:"keys"`
+	Ports      []int    `json:"ports"`
+	Limit      int      `json:"limit"`
+}
+
+type policyConfig struct {
+	Mode  string                `json:"mode"` // warn | enforce
+	Rules map[string]policyRule `json:"rules"`
+}
+
+type Violation struct {
+	Rule     string `json:"rule"`
+	Severity string `json:"severity"`
+	Address  string `json:"address,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Message  string `json:"message"`
+}
+
+type PolicyResult struct {
+	Verdict    string      `json:"verdict"` // pass | warn | fail
+	Mode       string      `json:"mode"`
+	Denies     int         `json:"denies"`
+	Warns      int         `json:"warns"`
+	Violations []Violation `json:"violations"`
+}
+
+func parsePolicyConfig(raw any) *policyConfig {
+	if raw == nil {
+		return nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var cfg policyConfig
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return nil
+	}
+	if cfg.Mode != "enforce" {
+		cfg.Mode = "warn"
+	}
+	if len(cfg.Rules) == 0 {
+		return nil
+	}
+	for _, r := range cfg.Rules {
+		if r.Enabled {
+			return &cfg
+		}
+	}
+	return nil
+}
+
+type planChange struct {
+	Actions []string       `json:"actions"`
+	After   map[string]any `json:"after"`
+}
+
+type planResourceChange struct {
+	Address string     `json:"address"`
+	Type    string     `json:"type"`
+	Change  planChange `json:"change"`
+}
+
+type planJSON struct {
+	ResourceChanges []planResourceChange `json:"resource_changes"`
+}
+
+func showPlanJSON(stackDir, planFile string, env []string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tofu", "show", "-json", planFile)
+	cmd.Dir = stackDir
+	cmd.Env = env
+	return cmd.Output()
+}
+
+func hasAction(actions []string, want string) bool {
+	for _, a := range actions {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sevOf(r policyRule) string {
+	if r.Severity == "deny" {
+		return "deny"
+	}
+	return "warn"
+}
+
+// evaluatePolicy applies the enabled rules to the plan JSON.
+func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
+	var plan planJSON
+	if err := json.Unmarshal(raw, &plan); err != nil {
+		return nil, err
+	}
+
+	res := &PolicyResult{Verdict: "pass", Mode: cfg.Mode, Violations: []Violation{}}
+	add := func(rule, sev, addr, rtype, msg string) {
+		res.Violations = append(res.Violations, Violation{
+			Rule: rule, Severity: sev, Address: addr, Type: rtype, Message: msg,
+		})
+	}
+
+	destroyed, created := 0, 0
+	for _, rc := range plan.ResourceChanges {
+		if hasAction(rc.Change.Actions, "delete") {
+			destroyed++
+		}
+		if hasAction(rc.Change.Actions, "create") {
+			created++
+		}
+	}
+
+	// --- deny_destroy -------------------------------------------------------
+	if r, ok := cfg.Rules["deny_destroy"]; ok && r.Enabled && destroyed > r.MaxDestroy {
+		for _, rc := range plan.ResourceChanges {
+			if hasAction(rc.Change.Actions, "delete") {
+				add("deny_destroy", sevOf(r), rc.Address, rc.Type,
+					fmt.Sprintf("resource would be destroyed (%d destroy(s), limit %d)", destroyed, r.MaxDestroy))
+			}
+		}
+	}
+
+	// --- denied_resource_types ---------------------------------------------
+	if r, ok := cfg.Rules["denied_resource_types"]; ok && r.Enabled && len(r.Types) > 0 {
+		denied := map[string]bool{}
+		for _, t := range r.Types {
+			denied[strings.ToLower(strings.TrimSpace(t))] = true
+		}
+		for _, rc := range plan.ResourceChanges {
+			if hasAction(rc.Change.Actions, "no-op") || hasAction(rc.Change.Actions, "delete") {
+				continue
+			}
+			if denied[strings.ToLower(rc.Type)] {
+				add("denied_resource_types", sevOf(r), rc.Address, rc.Type,
+					"resource type is on the denied list")
+			}
+		}
+	}
+
+	// --- require_tags -------------------------------------------------------
+	if r, ok := cfg.Rules["require_tags"]; ok && r.Enabled && len(r.Keys) > 0 {
+		for _, rc := range plan.ResourceChanges {
+			if !hasAction(rc.Change.Actions, "create") && !hasAction(rc.Change.Actions, "update") {
+				continue
+			}
+			tags := resourceTags(rc.Change.After)
+			if tags == nil {
+				continue // resource isn't taggable — don't punish it
+			}
+			var missing []string
+			for _, k := range r.Keys {
+				if _, ok := tags[strings.ToLower(k)]; !ok {
+					missing = append(missing, k)
+				}
+			}
+			if len(missing) > 0 {
+				sort.Strings(missing)
+				add("require_tags", sevOf(r), rc.Address, rc.Type,
+					"missing required tag(s): "+strings.Join(missing, ", "))
+			}
+		}
+	}
+
+	// --- deny_public_ingress ------------------------------------------------
+	if r, ok := cfg.Rules["deny_public_ingress"]; ok && r.Enabled {
+		ports := r.Ports
+		if len(ports) == 0 {
+			ports = []int{22, 3389}
+		}
+		for _, rc := range plan.ResourceChanges {
+			if hasAction(rc.Change.Actions, "delete") || hasAction(rc.Change.Actions, "no-op") {
+				continue
+			}
+			for _, hit := range publicIngressHits(rc.Change.After, ports) {
+				add("deny_public_ingress", sevOf(r), rc.Address, rc.Type,
+					"ingress rule opens port "+hit+" to the whole internet (0.0.0.0/0 or ::/0)")
+			}
+		}
+	}
+
+	// --- max_created --------------------------------------------------------
+	if r, ok := cfg.Rules["max_created"]; ok && r.Enabled && r.Limit > 0 && created > r.Limit {
+		add("max_created", sevOf(r), "", "",
+			fmt.Sprintf("plan creates %d resources, above the limit of %d", created, r.Limit))
+	}
+
+	for _, v := range res.Violations {
+		if v.Severity == "deny" {
+			res.Denies++
+		} else {
+			res.Warns++
+		}
+	}
+	switch {
+	case res.Denies > 0:
+		res.Verdict = "fail"
+	case res.Warns > 0:
+		res.Verdict = "warn"
+	}
+	return res, nil
+}
+
+func resourceTags(after map[string]any) map[string]string {
+	if after == nil {
+		return nil
+	}
+	for _, key := range []string{"tags", "tags_all", "labels"} {
+		v, ok := after[key]
+		if !ok || v == nil {
+			continue
+		}
+		out := map[string]string{}
+		switch t := v.(type) {
+		case map[string]any:
+			for k, val := range t {
+				out[strings.ToLower(k)] = fmt.Sprint(val)
+			}
+			return out
+		case []any: // e.g. [{key=..., value=...}] or ["a","b"]
+			for _, e := range t {
+				switch item := e.(type) {
+				case map[string]any:
+					if k, ok := item["key"]; ok {
+						out[strings.ToLower(fmt.Sprint(k))] = fmt.Sprint(item["value"])
+					}
+				case string:
+					out[strings.ToLower(item)] = ""
+				}
+			}
+			return out
+		}
+	}
+	return nil
+}
+
+var openCIDRs = map[string]bool{"0.0.0.0/0": true, "::/0": true, "0.0.0.0/0,::/0": true}
+
+func publicIngressHits(after map[string]any, ports []int) []string {
+	if after == nil {
+		return nil
+	}
+	var hits []string
+	seen := map[string]bool{}
+
+	consider := func(rule map[string]any) {
+		dir, _ := rule["direction"].(string)
+		if dir != "" && !strings.EqualFold(dir, "in") && !strings.EqualFold(dir, "ingress") &&
+			!strings.EqualFold(dir, "inbound") {
+			return
+		}
+		if !ruleIsOpenToWorld(rule) {
+			return
+		}
+		for _, p := range ports {
+			if ruleCoversPort(rule, p) {
+				key := fmt.Sprint(p)
+				if !seen[key] {
+					seen[key] = true
+					hits = append(hits, key)
+				}
+			}
+		}
+	}
+
+	for _, key := range []string{"ingress", "rule", "firewall_rule", "security_rules", "rules"} {
+		v, ok := after[key]
+		if !ok {
+			continue
+		}
+		switch t := v.(type) {
+		case []any:
+			for _, e := range t {
+				if m, ok := e.(map[string]any); ok {
+					consider(m)
+				}
+			}
+		case map[string]any:
+			consider(t)
+		}
+	}
+	// Flat single-rule resources (aws_vpc_security_group_ingress_rule, etc.)
+	if _, hasCidr := after["cidr_ipv4"]; hasCidr {
+		consider(after)
+	} else if _, hasCidr := after["cidr_blocks"]; hasCidr {
+		consider(after)
+	}
+	sort.Strings(hits)
+	return hits
+}
+
+func ruleIsOpenToWorld(rule map[string]any) bool {
+	for _, key := range []string{"cidr_blocks", "ipv6_cidr_blocks", "source_ips", "cidr_ipv4", "cidr_ipv6", "source_addresses", "remote_ip_prefix"} {
+		v, ok := rule[key]
+		if !ok || v == nil {
+			continue
+		}
+		switch t := v.(type) {
+		case string:
+			if openCIDRs[strings.TrimSpace(t)] {
+				return true
+			}
+		case []any:
+			for _, e := range t {
+				if s, ok := e.(string); ok && openCIDRs[strings.TrimSpace(s)] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func asInt(v any) (int, bool) {
+	switch t := v.(type) {
+	case float64:
+		return int(t), true
+	case int:
+		return t, true
+	case string:
+		s := strings.TrimSpace(t)
+		if s == "" {
+			return 0, false
+		}
+		var n int
+		if _, err := fmt.Sscanf(s, "%d", &n); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func ruleCoversPort(rule map[string]any, p int) bool {
+	if proto, ok := rule["protocol"].(string); ok {
+		lp := strings.ToLower(strings.TrimSpace(proto))
+		if lp == "icmp" || lp == "icmpv6" {
+			return false
+		}
+	}
+	// Explicit "port" / "port_range" strings, e.g. "22", "20-80", "any".
+	for _, key := range []string{"port", "port_range", "ports", "destination_port_range"} {
+		v, ok := rule[key]
+		if !ok || v == nil {
+			continue
+		}
+		s := strings.TrimSpace(fmt.Sprint(v))
+		if s == "" || strings.EqualFold(s, "any") || s == "*" || s == "1-65535" || s == "0-65535" {
+			return true
+		}
+		if strings.Contains(s, "-") {
+			parts := strings.SplitN(s, "-", 2)
+			from, ok1 := asInt(parts[0])
+			to, ok2 := asInt(parts[1])
+			if ok1 && ok2 && p >= from && p <= to {
+				return true
+			}
+			continue
+		}
+		for _, chunk := range strings.Split(s, ",") {
+			if n, ok := asInt(strings.TrimSpace(chunk)); ok && n == p {
+				return true
+			}
+		}
+	}
+	from, ok1 := asInt(rule["from_port"])
+	to, ok2 := asInt(rule["to_port"])
+	if ok1 && ok2 {
+		if from == 0 && to == 0 {
+			return true // "all ports" convention
+		}
+		return p >= from && p <= to
+	}
+
+	_, hasAnyPortKey := rule["from_port"]
+	return !hasAnyPortKey
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+func formatPolicyReport(res *PolicyResult) string {
+	var b strings.Builder
+	b.WriteString("\n[policy] ── Policy-as-code gate ──────────────────────────────\n")
+	b.WriteString(fmt.Sprintf("[policy] mode=%s  deny=%d  warn=%d\n", res.Mode, res.Denies, res.Warns))
+	if len(res.Violations) == 0 {
+		b.WriteString("[policy] PASS — no violations found.\n\n")
+		return b.String()
+	}
+	for _, v := range res.Violations {
+		label := "WARN"
+		if v.Severity == "deny" {
+			label = "DENY"
+		}
+		addr := v.Address
+		if addr == "" {
+			addr = "(plan)"
+		}
+		b.WriteString(fmt.Sprintf("[policy] %s  %-22s %s — %s\n", label, v.Rule, addr, v.Message))
+	}
+	switch {
+	case res.Denies > 0 && res.Mode == "enforce":
+		b.WriteString("[policy] FAILED — the run is blocked because the gate is in enforce mode.\n\n")
+	case res.Denies > 0:
+		b.WriteString("[policy] Violations found, but the gate is in warn mode — continuing.\n\n")
+	default:
+		b.WriteString("[policy] Warnings only — continuing.\n\n")
+	}
+	return b.String()
+}

--- a/worker/internal/execute/tofu.go
+++ b/worker/internal/execute/tofu.go
@@ -262,14 +262,21 @@ func executeTofuRun(executionID string, execData map[string]any, projectID strin
 	var returnCode *int
 	var credsPath string
 
+	policyCfg := parsePolicyConfig(runParams["policy"])
+	var policyRes *PolicyResult
+
 	defer func() {
 		if credsPath != "" {
 			_ = os.Remove(credsPath)
 		}
 		duration := int(time.Since(startTime).Seconds())
-		client.FinishExecution(executionID, finalStatus, float64(time.Now().Unix()), duration, returnCode, "",
-			map[string]any{"tofu_action": action, "stack": stackName})
+		result := map[string]any{"tofu_action": action, "stack": stackName}
+		if policyRes != nil {
+			result["policy"] = policyRes
+		}
+		client.FinishExecution(executionID, finalStatus, float64(time.Now().Unix()), duration, returnCode, "", result)
 	}()
+
 
 	client.Heartbeat(executionID)
 
@@ -353,6 +360,54 @@ func executeTofuRun(executionID string, execData map[string]any, projectID strin
 		}
 		env = append(env, k+"="+fmt.Sprint(v))
 	}
+
+	// ---- Policy-as-code pre-flight gate -----------------------------------
+	if policyCfg != nil && (strings.EqualFold(action, "apply") || strings.EqualFold(action, "destroy")) {
+		sendLog("[policy] gate enabled — running a speculative plan before " + strings.ToLower(action) + "...\n")
+		planFile := ".opensible-policy.tfplan"
+		pargs := []string{"plan", "-input=false", "-no-color", "-out=" + planFile}
+		if strings.EqualFold(action, "destroy") {
+			pargs = append(pargs, "-destroy")
+		}
+		pctx, pcancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		pcmd := exec.CommandContext(pctx, "tofu", pargs...)
+		pcmd.Dir = stackDir
+		pcmd.Env = env
+		pout, perr := pcmd.CombinedOutput()
+		pcancel()
+		if perr != nil {
+			sendLog(string(pout))
+			sendLog("[policy] ERROR: speculative plan failed — cannot evaluate policy, aborting.\n")
+			rc := 1
+			returnCode = &rc
+			_ = os.Remove(filepath.Join(stackDir, planFile))
+			return
+		}
+		raw, serr := showPlanJSON(stackDir, planFile, env)
+		_ = os.Remove(filepath.Join(stackDir, planFile))
+		if serr != nil {
+			sendLog("[policy] ERROR: `tofu show -json` failed: " + serr.Error() + " — aborting.\n")
+			rc := 1
+			returnCode = &rc
+			return
+		}
+		res, eerr := evaluatePolicy(raw, policyCfg)
+		if eerr != nil {
+			sendLog("[policy] ERROR: could not parse plan JSON: " + eerr.Error() + " — aborting.\n")
+			rc := 1
+			returnCode = &rc
+			return
+		}
+		policyRes = res
+		sendLog(formatPolicyReport(res))
+		if res.Denies > 0 && policyCfg.Mode == "enforce" {
+			finalStatus = "FAILED"
+			rc := 3
+			returnCode = &rc
+			return
+		}
+	}
+
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -476,9 +531,28 @@ loop:
 			sendLog("\n[drift] DRIFT DETECTED — the live infrastructure differs from the recorded state (see plan above).\n")
 		}
 	}
+
+	if policyCfg != nil && strings.EqualFold(action, "plan") && finalStatus == "SUCCESS" && !killed {
+		if raw, serr := showPlanJSON(stackDir, "tfplan", env); serr == nil {
+			if res, eerr := evaluatePolicy(raw, policyCfg); eerr == nil {
+				policyRes = res
+				sendLog(formatPolicyReport(res))
+				if res.Denies > 0 && policyCfg.Mode == "enforce" {
+					finalStatus = "FAILED"
+					rc := 3
+					returnCode = &rc
+				}
+			} else {
+				sendLog("[policy] WARNING: could not parse plan JSON: " + eerr.Error() + "\n")
+			}
+		} else {
+			sendLog("[policy] WARNING: `tofu show -json tfplan` failed: " + serr.Error() + "\n")
+		}
+	}
 	if killed {
 		finalStatus = "CANCELED"
 	}
+
 
 	// Snapshot tfstate on success.
 	if finalStatus == "SUCCESS" && (action == "apply" || action == "destroy" || action == "refresh" || action == "plan") {


### PR DESCRIPTION
- Plan diff UX for cloud stack provisioning runs
- Policy-as-code gate management card on the Cloud Stack detail page
- Displays the last policy verdict (pass / warn / fail) with a detailed violation list.
- Added a lightweight, opt-in Policy-as-code gate for Cloud Provisioning stacks (server)
- Added in-process Policy-as-code evaluation for Cloud Provisioning stacks (worker)