### PR TITLE
feat: custom policy rules with check DSL (worker + backend)

### DIFF
--- a/server/services/cloud_policy.py
+++ b/server/services/cloud_policy.py
@@ -4,8 +4,9 @@ Policy-as-code gate for Cloud Provisioning stacks (opt-in per stack).
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from flask import jsonify, request
 
@@ -20,6 +21,33 @@ POLICY_RULE_TYPES = {
 SEVERITIES = ("warn", "deny")
 ENFORCEMENTS = ("inherit", "block", "report")
 
+# Custom (user-defined) rules: richer severities and a YAML/JSON check DSL.
+#   "info"           -> report only, never blocks
+#   "warning"        -> blocks only when the gate runs in enforce mode
+#   "error"          -> deny-severity: blocks in enforce mode, or always with
+#                       enforcement "block"
+CUSTOM_SEVERITIES = ("info", "warning", "error")
+CUSTOM_ENFORCEMENTS = ("inherit", "block", "report")
+CUSTOM_TARGETS = ("resource", "output", "config")
+CUSTOM_OPERATORS = frozenset(
+    {
+        "exists",
+        "not_exists",
+        "equals",
+        "not_equals",
+        "contains",
+        "not_contains",
+        "matches",
+        "not_matches",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+    }
+)
+MAX_CUSTOM_RULES = 50
+_CUSTOM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+
 
 def default_policy() -> Dict[str, Any]:
     """Conservative starting point: everything off except the two cheap,
@@ -33,6 +61,7 @@ def default_policy() -> Dict[str, Any]:
             "deny_public_ingress": {"enabled": True, "severity": "deny", "enforcement": "inherit", "ports": [22, 3389]},
             "max_created": {"enabled": False, "severity": "warn", "enforcement": "inherit", "limit": 50},
         },
+        "custom_rules": [],
     }
 
 
@@ -50,7 +79,89 @@ def policy_config_from_meta(meta: Dict[str, Any]) -> Dict[str, Any]:
         for rid, rule in (stored.get("rules") or {}).items():
             if rid in cfg["rules"] and isinstance(rule, dict):
                 cfg["rules"][rid].update({k: v for k, v in rule.items() if k != "id"})
+        if isinstance(stored.get("custom_rules"), list):
+            cfg["custom_rules"] = sanitize_custom_rules(stored["custom_rules"])
     return cfg
+
+
+def _clean_str(value: Any, max_len: int = 500) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()[:max_len]
+
+
+def sanitize_custom_rules(rules: Any) -> List[Dict[str, Any]]:
+    """Whitelist the custom-rule schema. Structure is validated here; regex
+    patterns and path resolution are validated by the worker (RE2), whose
+    findings surface in the policy result's `errors` field."""
+    if not isinstance(rules, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+    for rule in rules[:MAX_CUSTOM_RULES]:
+        if not isinstance(rule, dict):
+            continue
+        rid = _clean_str(rule.get("id"), 64)
+        if not _CUSTOM_ID_RE.match(rid) or rid in seen_ids:
+            continue
+        seen_ids.add(rid)
+
+        severity = _clean_str(rule.get("severity"), 32).lower()
+        if severity not in CUSTOM_SEVERITIES:
+            severity = "warning"
+        enforcement = _clean_str(rule.get("enforcement"), 32).lower()
+        if enforcement not in CUSTOM_ENFORCEMENTS:
+            enforcement = "inherit"
+        if severity == "info":
+            enforcement = "report"  # info-severity rules can never block
+        target = _clean_str(rule.get("target"), 32).lower()
+        if target not in CUSTOM_TARGETS:
+            target = "resource"
+
+        match: Dict[str, Any] = {"types": [], "addresses": [], "actions": []}
+        if isinstance(rule.get("match"), dict):
+            incoming_match = rule["match"]
+            for key in ("types", "addresses"):
+                items = incoming_match.get(key)
+                if isinstance(items, list):
+                    match[key] = [
+                        _clean_str(x, 200) for x in items if isinstance(x, str) and x.strip()
+                    ][:100]
+            actions = incoming_match.get("actions")
+            if isinstance(actions, list):
+                match["actions"] = [
+                    _clean_str(x, 50).lower() for x in actions if isinstance(x, str) and x.strip()
+                ][:50]
+
+        checks: List[Dict[str, Any]] = []
+        incoming_checks = rule.get("checks")
+        if isinstance(incoming_checks, list):
+            for c in incoming_checks[:100]:
+                if not isinstance(c, dict):
+                    continue
+                op = _clean_str(c.get("operator"), 32).lower()
+                if op not in CUSTOM_OPERATORS:
+                    continue
+                checks.append({"path": _clean_str(c.get("path"), 300), "operator": op, "value": c.get("value")})
+        if not checks:
+            continue
+
+        out.append(
+            {
+                "id": rid,
+                "name": _clean_str(rule.get("name"), 200),
+                "description": _clean_str(rule.get("description"), 500),
+                "category": _clean_str(rule.get("category"), 100),
+                "enabled": bool(rule.get("enabled")),
+                "severity": severity,
+                "enforcement": enforcement,
+                "target": target,
+                "match": match,
+                "checks": checks,
+                "message": _clean_str(rule.get("message"), 500),
+            }
+        )
+    return out
 
 
 def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
@@ -58,6 +169,7 @@ def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
     mode = (body.get("mode") or "").strip().lower()
     if mode in ("warn", "enforce"):
         cfg["mode"] = mode
+    cfg["custom_rules"] = sanitize_custom_rules(body.get("custom_rules"))
     rules = body.get("rules") or {}
     if not isinstance(rules, dict):
         return cfg
@@ -132,6 +244,7 @@ def latest_policy_result(ex_dir: Path, name: str) -> Optional[Dict[str, Any]]:
             "blocked": bool(pol.get("blocked")),
             "blocked_by": pol.get("blocked_by") or [],
             "violations": pol.get("violations") or [],
+            "errors": pol.get("errors") or [],
         }
     return None
 

--- a/worker/internal/execute/custom.go
+++ b/worker/internal/execute/custom.go
@@ -1,0 +1,729 @@
+// Custom policy rules: user-defined validation checks evaluated against the
+// plan JSON (resource_changes / output_changes) or the rendered tfvars file.
+package execute
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	targetResource = "resource"
+	targetOutput   = "output"
+	targetConfig   = "config"
+)
+
+var customTargets = map[string]bool{
+	targetResource: true,
+	targetOutput:   true,
+	targetConfig:   true,
+}
+
+var customSeverities = map[string]bool{
+	"info":    true,
+	"warning": true,
+	"error":   true,
+}
+
+var customOperators = map[string]bool{
+	"exists":       true,
+	"not_exists":   true,
+	"equals":       true,
+	"not_equals":   true,
+	"contains":     true,
+	"not_contains": true,
+	"matches":      true,
+	"not_matches":  true,
+	"gt":           true,
+	"gte":          true,
+	"lt":           true,
+	"lte":          true,
+}
+
+// customMatch selects which plan entries a custom rule applies to. Empty
+// slices mean "any" (no filter). Types and addresses are RE2 regex patterns;
+// actions are matched exactly.
+type customMatch struct {
+	Types     []string `json:"types"`
+	Addresses []string `json:"addresses"`
+	Actions   []string `json:"actions"`
+}
+
+type customCheck struct {
+	Path     string `json:"path"`
+	Operator string `json:"operator"`
+	Value    any    `json:"value,omitempty"`
+}
+
+type customRule struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Category    string        `json:"category"`
+	Enabled     bool          `json:"enabled"`
+	Severity    string        `json:"severity"`    // info | warning | error
+	Enforcement string        `json:"enforcement"` // inherit | block | report (empty == inherit)
+	Target      string        `json:"target"`      // resource | output | config
+	Match       customMatch   `json:"match"`
+	Checks      []customCheck `json:"checks"`
+	Message     string        `json:"message"`
+}
+
+// customBlocksWhen mirrors ruleBlocks for the richer severity set:
+//   - "info": never blocks.
+//   - "block": always blocks.
+//   - "report": never blocks.
+//   - "inherit" (default): blocks only in enforce mode.
+func customBlocksWhen(sev, enf, gateMode string) bool {
+	sev = strings.ToLower(strings.TrimSpace(sev))
+	if sev == "info" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(enf)) {
+	case "block":
+		return true
+	case "report":
+		return false
+	default: // "inherit" or empty
+		return gateMode == "enforce"
+	}
+}
+
+// evaluateCustomRules appends violations (and configuration errors) to res.
+func evaluateCustomRules(res *PolicyResult, plan *planJSON, cfg *policyConfig, stackDir string) {
+	for _, rule := range cfg.CustomRules {
+		if !rule.Enabled {
+			continue
+		}
+		if err := validateCustomRule(&rule); err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("custom rule %q: %v", rule.ID, err))
+			continue
+		}
+		blocking := customBlocksWhen(rule.Severity, rule.Enforcement, cfg.Mode)
+		var hits []customHit
+		switch rule.Target {
+		case targetResource:
+			hits = evalCustomResources(plan, &rule)
+		case targetOutput:
+			hits = evalCustomOutputs(plan, &rule)
+		case targetConfig:
+			hits = evalCustomConfig(rule, stackDir)
+		}
+		if len(hits) == 0 {
+			continue
+		}
+		for _, c := range hits {
+			if !customRuleMatches(&rule, c.Root) {
+				continue
+			}
+			res.Violations = append(res.Violations, Violation{
+				Rule:     rule.ID,
+				Severity: rule.Severity,
+				Blocking: blocking,
+				Address:  c.Address,
+				Type:     c.Type,
+				Message:  customMessage(&rule, c.Address),
+			})
+		}
+	}
+}
+
+type customHit struct {
+	Address string
+	Type    string
+	Root    any
+}
+
+// customRuleMatches reports whether every check of the rule passes for root.
+// All conditions must hold for the rule to fire (AND semantics).
+func customRuleMatches(rule *customRule, root any) bool {
+	for _, c := range rule.Checks {
+		if !customCheckPasses(c, root) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateCustomRule(r *customRule) error {
+	if strings.TrimSpace(r.ID) == "" {
+		return fmt.Errorf("rule is missing an id")
+	}
+	if !customSeverities[strings.ToLower(strings.TrimSpace(r.Severity))] {
+		return fmt.Errorf("unknown severity %q (want info, warning or error)", r.Severity)
+	}
+	if !customTargets[strings.ToLower(strings.TrimSpace(r.Target))] {
+		return fmt.Errorf("unknown target %q (want resource, output or config)", r.Target)
+	}
+	enf := strings.ToLower(strings.TrimSpace(r.Enforcement))
+	if enf != "" && enf != "inherit" && enf != "block" && enf != "report" {
+		return fmt.Errorf("unknown enforcement %q (want inherit, block or report)", r.Enforcement)
+	}
+	if len(r.Checks) == 0 {
+		return fmt.Errorf("rule has no checks")
+	}
+	for _, expr := range r.Match.Types {
+		if _, err := regexp.Compile(expr); err != nil {
+			return fmt.Errorf("invalid type pattern %q: %v", expr, err)
+		}
+	}
+	for _, expr := range r.Match.Addresses {
+		if _, err := regexp.Compile(expr); err != nil {
+			return fmt.Errorf("invalid address pattern %q: %v", expr, err)
+		}
+	}
+	for _, c := range r.Checks {
+		op := strings.ToLower(strings.TrimSpace(c.Operator))
+		if !customOperators[op] {
+			return fmt.Errorf("unknown operator %q in check %q", c.Operator, c.Path)
+		}
+		if strings.HasPrefix(op, "matches") {
+			expr, ok := c.Value.(string)
+			if !ok {
+				return fmt.Errorf("check %q needs a valid regex value", c.Path)
+			}
+			if _, err := regexp.Compile(expr); err != nil {
+				return fmt.Errorf("check %q has an invalid regex: %v", c.Path, err)
+			}
+		}
+	}
+	return nil
+}
+
+func customMessage(r *customRule, addr string) string {
+	msg := strings.TrimSpace(r.Message)
+	if msg == "" {
+		msg = strings.TrimSpace(r.Name)
+	}
+	if msg == "" {
+		msg = "custom rule violation"
+	}
+	if addr != "" {
+		msg += " (" + addr + ")"
+	}
+	return msg
+}
+
+func matchesAny(pats []string, s string) bool {
+	for _, p := range pats {
+		re, err := regexp.Compile(p)
+		if err == nil && re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func actionsContain(actions []string, want []string) bool {
+	for _, w := range want {
+		for _, a := range actions {
+			if a == w {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func evalCustomResources(plan *planJSON, rule *customRule) []customHit {
+	var hits []customHit
+	for _, rc := range plan.ResourceChanges {
+		if len(rule.Match.Types) > 0 && !matchesAny(rule.Match.Types, rc.Type) {
+			continue
+		}
+		if len(rule.Match.Addresses) > 0 && !matchesAny(rule.Match.Addresses, rc.Address) {
+			continue
+		}
+		if len(rule.Match.Actions) > 0 && !actionsContain(rc.Change.Actions, rule.Match.Actions) {
+			continue
+		}
+		hits = append(hits, customHit{Address: rc.Address, Type: rc.Type, Root: rc.Change.After})
+	}
+	return hits
+}
+
+func evalCustomOutputs(plan *planJSON, rule *customRule) []customHit {
+	var hits []customHit
+	for name, oc := range plan.OutputChanges {
+		if len(rule.Match.Addresses) > 0 && !matchesAny(rule.Match.Addresses, name) {
+			continue
+		}
+		if len(rule.Match.Actions) > 0 && !actionsContain(oc.Actions, rule.Match.Actions) {
+			continue
+		}
+		hits = append(hits, customHit{Address: "output." + name, Root: oc.After})
+	}
+	return hits
+}
+
+func evalCustomConfig(rule customRule, stackDir string) []customHit {
+	if stackDir == "" {
+		return nil
+	}
+	src, err := os.ReadFile(filepath.Join(stackDir, "terraform.tfvars"))
+	if err != nil {
+		return nil // no rendered tfvars on the worker — nothing to check
+	}
+	vals, err := parseTfvars(string(src))
+	if err != nil {
+		return nil
+	}
+	return []customHit{{Address: "config", Root: vals}}
+}
+
+func customCheckPasses(c customCheck, root any) bool {
+	op := strings.ToLower(strings.TrimSpace(c.Operator))
+	got, ok := resolvePath(root, c.Path)
+	switch op {
+	case "exists":
+		return ok && len(got) > 0
+	case "not_exists":
+		return !ok || len(got) == 0
+	case "not_equals", "not_contains", "not_matches":
+		if !ok || len(got) == 0 {
+			return false
+		}
+		for _, g := range got {
+			if customOpMatch(op[4:], g, c.Value) {
+				return false
+			}
+		}
+		return true
+	default:
+		if !ok || len(got) == 0 {
+			return false
+		}
+		for _, g := range got {
+			if customOpMatch(op, g, c.Value) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// resolvePath walks a dot-separated path (supporting `[0]` indices and `*`
+// wildcards) and returns every value matched. The empty result means the path
+// did not resolve.
+func resolvePath(root any, path string) ([]any, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "." {
+		return []any{root}, true
+	}
+	parts := strings.Split(path, ".")
+	vals := []any{root}
+	for _, part := range parts {
+		var next []any
+		if part == "*" {
+			for _, v := range vals {
+				switch t := v.(type) {
+				case []any:
+					next = append(next, t...)
+				case map[string]any:
+					for _, mv := range t {
+						next = append(next, mv)
+					}
+				}
+			}
+		} else if idx, isIdx := bracketIndex(part); isIdx {
+			for _, v := range vals {
+				if list, ok := v.([]any); ok && idx >= 0 && idx < len(list) {
+					next = append(next, list[idx])
+				}
+			}
+		} else {
+			for _, v := range vals {
+				if m, ok := v.(map[string]any); ok {
+					if mv, exists := m[part]; exists {
+						next = append(next, mv)
+					}
+				}
+			}
+		}
+		if len(next) == 0 {
+			return nil, false
+		}
+		vals = next
+	}
+	return vals, true
+}
+
+func bracketIndex(part string) (int, bool) {
+	if len(part) >= 3 && part[0] == '[' && part[len(part)-1] == ']' {
+		part = part[1 : len(part)-1]
+	}
+	n, err := strconv.Atoi(part)
+	return n, err == nil
+}
+
+func customOpMatch(op string, got, want any) bool {
+	switch op {
+	case "equals":
+		return valuesEqual(got, want)
+	case "contains":
+		return valueContains(got, want)
+	case "matches":
+		return valueMatches(got, want)
+	case "gt", "gte", "lt", "lte":
+		return valueCompare(op, got, want)
+	}
+	return false
+}
+
+func normalizeScalar(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(t), true
+	case int64:
+		return strconv.FormatInt(t, 10), true
+	}
+	return "", false
+}
+
+func valuesEqual(a, b any) bool {
+	sa, oka := normalizeScalar(a)
+	sb, okb := normalizeScalar(b)
+	if oka && okb {
+		return sa == sb
+	}
+	return a == nil && b == nil
+}
+
+func valueContains(got, want any) bool {
+	switch t := got.(type) {
+	case string:
+		if s, ok := want.(string); ok {
+			return strings.Contains(t, s)
+		}
+	case []any:
+		for _, e := range t {
+			if valuesEqual(e, want) {
+				return true
+			}
+		}
+	case map[string]any:
+		if s, ok := want.(string); ok {
+			_, exists := t[s]
+			return exists
+		}
+	}
+	return false
+}
+
+func valueMatches(got, want any) bool {
+	s, ok := normalizeScalar(got)
+	if !ok {
+		return false
+	}
+	expr, ok := want.(string)
+	if !ok {
+		return false
+	}
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(s)
+}
+
+func toFloat(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case float32:
+		return float64(t), true
+	case int:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(t), 64)
+		return f, err == nil
+	}
+	return 0, false
+}
+
+func valueCompare(op string, got, want any) bool {
+	gn, ok1 := toFloat(got)
+	wn, ok2 := toFloat(want)
+	if ok1 && ok2 {
+		switch op {
+		case "gt":
+			return gn > wn
+		case "gte":
+			return gn >= wn
+		case "lt":
+			return gn < wn
+		case "lte":
+			return gn <= wn
+		}
+	}
+	gs, ok1s := normalizeScalar(got)
+	ws, ok2s := normalizeScalar(want)
+	if ok1s && ok2s {
+		switch op {
+		case "gt":
+			return gs > ws
+		case "gte":
+			return gs >= ws
+		case "lt":
+			return gs < ws
+		case "lte":
+			return gs <= ws
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Minimal terraform.tfvars parser for the subset rendered by the server's
+// _render_value() (flat assignments, quoted strings, numbers, booleans, lists
+// and maps).
+// ---------------------------------------------------------------------------
+
+type tfvarToken struct {
+	kind byte
+	text string
+	num  float64
+}
+
+const (
+	tkEOF byte = iota
+	tkIdent
+	tkString
+	tkNumber
+	tkTrue
+	tkFalse
+	tkLBrak
+	tkRBrak
+	tkLBrace
+	tkRBrace
+	tkComma
+	tkEq
+)
+
+func parseTfvars(src string) (map[string]any, error) {
+	toks, err := tokenizeTfvars(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &tfvarParser{toks: toks}
+	out := map[string]any{}
+	for p.pos < len(p.toks) && p.peek().kind != tkEOF {
+		first := p.peek()
+		if first.kind != tkIdent {
+			return nil, fmt.Errorf("expected a variable name")
+		}
+		key := first.text
+		p.pos++
+		if p.peek().kind != tkEq {
+			return nil, fmt.Errorf("expected '=' after %q", key)
+		}
+		p.pos++
+		v, err := p.value()
+		if err != nil {
+			return nil, err
+		}
+		out[key] = v
+	}
+	return out, nil
+}
+
+type tfvarParser struct {
+	toks []tfvarToken
+	pos  int
+}
+
+func (p *tfvarParser) peek() tfvarToken {
+	if p.pos < len(p.toks) {
+		return p.toks[p.pos]
+	}
+	return tfvarToken{kind: tkEOF}
+}
+
+func (p *tfvarParser) value() (any, error) {
+	t := p.peek()
+	switch t.kind {
+	case tkString, tkNumber, tkTrue, tkFalse:
+		p.pos++
+		if t.kind == tkTrue {
+			return true, nil
+		}
+		if t.kind == tkFalse {
+			return false, nil
+		}
+		if t.kind == tkNumber {
+			return t.num, nil
+		}
+		return t.text, nil
+	case tkLBrak:
+		return p.list()
+	case tkLBrace:
+		return p.object()
+	}
+	return nil, fmt.Errorf("unexpected token in value")
+}
+
+func (p *tfvarParser) list() (any, error) {
+	p.pos++ // consume '['
+	out := []any{}
+	for {
+		t := p.peek()
+		if t.kind == tkRBrak {
+			p.pos++
+			return out, nil
+		}
+		if t.kind == tkEOF {
+			return nil, fmt.Errorf("unterminated list")
+		}
+		v, err := p.value()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+		if p.peek().kind == tkComma {
+			p.pos++
+			continue
+		}
+		if p.peek().kind != tkRBrak {
+			return nil, fmt.Errorf("expected ',' or ']' in list")
+		}
+	}
+}
+
+func (p *tfvarParser) object() (any, error) {
+	p.pos++ // consume '{'
+	out := map[string]any{}
+	for {
+		t := p.peek()
+		if t.kind == tkRBrace {
+			p.pos++
+			return out, nil
+		}
+		if t.kind == tkEOF {
+			return nil, fmt.Errorf("unterminated object")
+		}
+		if t.kind != tkIdent {
+			return nil, fmt.Errorf("expected a key inside object")
+		}
+		key := t.text
+		p.pos++
+		if p.peek().kind != tkEq {
+			return nil, fmt.Errorf("expected '=' after %q", key)
+		}
+		p.pos++
+		v, err := p.value()
+		if err != nil {
+			return nil, err
+		}
+		out[key] = v
+		if p.peek().kind == tkComma {
+			p.pos++
+		}
+	}
+}
+
+func tokenizeTfvars(src string) ([]tfvarToken, error) {
+	var toks []tfvarToken
+	i := 0
+	n := len(src)
+	for i < n {
+		c := src[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == '#':
+			for i < n && src[i] != '\n' {
+				i++
+			}
+		case c == '[':
+			toks = append(toks, tfvarToken{kind: tkLBrak})
+			i++
+		case c == ']':
+			toks = append(toks, tfvarToken{kind: tkRBrak})
+			i++
+		case c == '{':
+			toks = append(toks, tfvarToken{kind: tkLBrace})
+			i++
+		case c == '}':
+			toks = append(toks, tfvarToken{kind: tkRBrace})
+			i++
+		case c == ',':
+			toks = append(toks, tfvarToken{kind: tkComma})
+			i++
+		case c == '=':
+			toks = append(toks, tfvarToken{kind: tkEq})
+			i++
+		case c == '"':
+			start := i
+			i++
+			var b strings.Builder
+			for i < n && src[i] != '"' {
+				if src[i] == '\\' && i+1 < n {
+					next := src[i+1]
+					if next == '"' || next == '\\' {
+						b.WriteByte(next)
+						i += 2
+						continue
+					}
+				}
+				b.WriteByte(src[i])
+				i++
+			}
+			if i >= n {
+				return nil, fmt.Errorf("unterminated string starting at offset %d", start)
+			}
+			i++ // closing quote
+			toks = append(toks, tfvarToken{kind: tkString, text: b.String()})
+		case isIdentStart(c):
+			start := i
+			for i < n && isIdentPart(src[i]) {
+				i++
+			}
+			word := src[start:i]
+			switch word {
+			case "true":
+				toks = append(toks, tfvarToken{kind: tkTrue})
+			case "false":
+				toks = append(toks, tfvarToken{kind: tkFalse})
+			default:
+				toks = append(toks, tfvarToken{kind: tkIdent, text: word})
+			}
+		case c == '-' || (c >= '0' && c <= '9'):
+			start := i
+			if c == '-' {
+				i++
+			}
+			for i < n && ((src[i] >= '0' && src[i] <= '9') || src[i] == '.') {
+				i++
+			}
+			f, err := strconv.ParseFloat(src[start:i], 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid number %q", src[start:i])
+			}
+			toks = append(toks, tfvarToken{kind: tkNumber, num: f})
+		default:
+			return nil, fmt.Errorf("unexpected character %q at offset %d", string(c), i)
+		}
+	}
+	toks = append(toks, tfvarToken{kind: tkEOF})
+	return toks, nil
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '-' || c == '.'
+}

--- a/worker/internal/execute/custom_test.go
+++ b/worker/internal/execute/custom_test.go
@@ -1,0 +1,317 @@
+package execute
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func customPlanJSON(t *testing.T, outputAfter any) []byte {
+	t.Helper()
+	plan := map[string]any{
+		"resource_changes": []map[string]any{
+			{
+				"address": "aws_instance.db.0",
+				"type":    "aws_instance",
+				"change": map[string]any{
+					"actions": []string{"create"},
+					"after": map[string]any{
+						"instance_type": "t3.large",
+						"root_block_device": []map[string]any{
+							{"volume_size": 500, "encrypted": false},
+							{"volume_size": 50, "encrypted": true},
+						},
+						"tags": map[string]any{"owner": "platform"},
+					},
+				},
+			},
+			{
+				"address": "aws_s3_bucket.assets",
+				"type":    "aws_s3_bucket",
+				"change": map[string]any{
+					"actions": []string{"create"},
+					"after": map[string]any{
+						"acl":  "public-read",
+						"tags": map[string]any{"owner": "platform"},
+					},
+				},
+			},
+		},
+		"output_changes": map[string]any{
+			"endpoint_url": map[string]any{
+				"actions": []string{"create"},
+				"after":   "http://api.example.com",
+			},
+			"replicas": map[string]any{
+				"actions": []string{"create"},
+				"after":   outputAfter,
+			},
+		},
+	}
+	b, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	return b
+}
+
+func customConfig(t *testing.T, gateMode string, rules []map[string]any) *policyConfig {
+	t.Helper()
+	raw := map[string]any{"mode": gateMode, "custom_rules": rules}
+	cfg := parsePolicyConfig(raw)
+	if cfg == nil {
+		t.Fatalf("parsePolicyConfig returned nil")
+	}
+	return cfg
+}
+
+func TestCustomRuleResourceMatchAndEquals(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "warn", []map[string]any{{
+		"id":          "no_public_buckets",
+		"enabled":     true,
+		"severity":    "error",
+		"enforcement": "block",
+		"target":      "resource",
+		"match":       map[string]any{"types": []string{"^aws_s3_bucket$"}},
+		"checks":      []map[string]any{{"path": "acl", "operator": "equals", "value": "public-read"}},
+		"message":     "S3 bucket must be private",
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if !res.Blocked || len(res.BlockedBy) != 1 || res.BlockedBy[0] != "no_public_buckets" {
+		t.Fatalf("got blocked=%v blocked_by=%v", res.Blocked, res.BlockedBy)
+	}
+	if len(res.Violations) != 1 || res.Violations[0].Address != "aws_s3_bucket.assets" {
+		t.Fatalf("unexpected violations: %+v", res.Violations)
+	}
+}
+
+func TestCustomRuleRegexAddressMatch(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "warn", []map[string]any{{
+		"id":       "no_large_instances",
+		"enabled":  true,
+		"severity": "warning",
+		"target":   "resource",
+		"match":    map[string]any{"addresses": []string{"aws_instance\\.db\\.[0-9]+"}},
+		"checks":   []map[string]any{{"path": "instance_type", "operator": "matches", "value": "^t3\\."}},
+		"message":  "db instances must not be burstable t3",
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if res.Verdict != "warn" || res.Blocked || len(res.Violations) != 1 {
+		t.Fatalf("got verdict=%s blocked=%v violations=%d", res.Verdict, res.Blocked, len(res.Violations))
+	}
+}
+
+func TestCustomRuleWildcardPath(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "enforce", []map[string]any{{
+		"id":       "encrypt_disks",
+		"enabled":  true,
+		"severity": "error",
+		"target":   "resource",
+		"match":    map[string]any{"types": []string{"aws_instance"}},
+		"checks":   []map[string]any{{"path": "root_block_device.*.encrypted", "operator": "equals", "value": true}},
+		"message":  "root volumes must be encrypted",
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	// Second block device (encrypted: false) satisfies the wildcard -> violation.
+	if res.Verdict != "fail" || !res.Blocked || len(res.Violations) != 1 {
+		t.Fatalf("got verdict=%s blocked=%v violations=%d", res.Verdict, res.Blocked, len(res.Violations))
+	}
+}
+
+func TestCustomRuleOutputTarget(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "warn", []map[string]any{{
+		"id":       "no_http_endpoint",
+		"enabled":  true,
+		"severity": "warning",
+		"target":   "output",
+		"match":    map[string]any{"addresses": []string{"endpoint_url"}},
+		"checks":   []map[string]any{{"path": "", "operator": "not_matches", "value": "^https://"}},
+		"message":  "endpoint must be https",
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if len(res.Violations) != 1 || res.Violations[0].Address != "output.endpoint_url" {
+		t.Fatalf("unexpected violations: %+v", res.Violations)
+	}
+}
+
+func TestCustomRuleSeverityInfoNeverBlocks(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "enforce", []map[string]any{{
+		"id":       "info_only",
+		"enabled":  true,
+		"severity": "info",
+		"target":   "resource",
+		"checks":   []map[string]any{{"path": "instance_type", "operator": "equals", "value": "t3.large"}},
+		"message":  "informational",
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if res.Blocked || res.Warns != 1 || res.Denies != 0 {
+		t.Fatalf("info must never block: blocked=%v warns=%d denies=%d", res.Blocked, res.Warns, res.Denies)
+	}
+}
+
+func TestCustomRuleErrorBlockEnforcement(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "warn", []map[string]any{{
+		"id":          "hard_error",
+		"enabled":     true,
+		"severity":    "error",
+		"enforcement": "block",
+		"target":      "resource",
+		"match":       map[string]any{"types": []string{"aws_s3_bucket"}},
+		"checks":      []map[string]any{{"path": "acl", "operator": "equals", "value": "public-read"}},
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if !res.Blocked || len(res.BlockedBy) != 1 || res.Denies != 1 {
+		t.Fatalf("error+block must block in warn mode: blocked=%v blocked_by=%v denies=%d", res.Blocked, res.BlockedBy, res.Denies)
+	}
+}
+
+func TestCustomRuleConfigTarget(t *testing.T) {
+	dir := t.TempDir()
+	tfvars := "# comment\n" +
+		"region = \"eu-west-1\"\n" +
+		"instance_count = 3\n" +
+		"enable_nat = true\n" +
+		"zones = [\"a\", \"b\", \"c\"]\n" +
+		"labels = {\n" +
+		"  env = \"prod\"\n" +
+		"}\n"
+	if err := os.WriteFile(filepath.Join(dir, "terraform.tfvars"), []byte(tfvars), 0o600); err != nil {
+		t.Fatalf("write tfvars: %v", err)
+	}
+	raw := customPlanJSON(t, nil)
+
+	cfg := customConfig(t, "enforce", []map[string]any{{
+		"id":       "prod_requires_tier",
+		"enabled":  true,
+		"severity": "error",
+		"target":   "config",
+		"checks": []map[string]any{
+			{"path": "labels.env", "operator": "equals", "value": "prod"},
+			{"path": "labels.tier", "operator": "not_exists"},
+		},
+		"message": "prod configs must set labels.tier",
+	}})
+	res, err := evaluatePolicy(raw, cfg, dir)
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if len(res.Violations) != 1 || res.Violations[0].Address != "config" {
+		t.Fatalf("unexpected violations: %+v", res.Violations)
+	}
+}
+
+func TestCustomRuleConfigMissingTfvarsSkips(t *testing.T) {
+	// No terraform.tfvars in the (empty) temp dir -> rule silently skips.
+	dir := t.TempDir()
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "enforce", []map[string]any{{
+		"id":       "needs_tfvars",
+		"enabled":  true,
+		"severity": "error",
+		"target":   "config",
+		"checks":   []map[string]any{{"path": "anything", "operator": "exists"}},
+	}})
+	res, err := evaluatePolicy(raw, cfg, dir)
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if len(res.Violations) != 0 {
+		t.Fatalf("expected no violations, got %+v", res.Violations)
+	}
+}
+
+func TestCustomRuleInvalidRegexSurfacesError(t *testing.T) {
+	raw := customPlanJSON(t, nil)
+	cfg := customConfig(t, "warn", []map[string]any{{
+		"id":       "broken",
+		"enabled":  true,
+		"severity": "error",
+		"target":   "resource",
+		"match":    map[string]any{"types": []string{"[unclosed"}},
+		"checks":   []map[string]any{{"path": "acl", "operator": "equals", "value": "public-read"}},
+	}})
+	res, err := evaluatePolicy(raw, cfg, "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if len(res.Errors) != 1 || !strings.Contains(res.Errors[0], "broken") {
+		t.Fatalf("expected a surfaced config error, got %+v", res.Errors)
+	}
+}
+
+func TestParseTfvars(t *testing.T) {
+	src := "a = \"hello\"\n" +
+		"b = 42\n" +
+		"c = -1.5\n" +
+		"d = true\n" +
+		"e = [\"x\", 1, false]\n" +
+		"f = {\n  inner = \"v\"\n}\n" +
+		"quoted = \"escaped \\\"quote\\\" and \\\\ slash\"\n"
+	vals, err := parseTfvars(src)
+	if err != nil {
+		t.Fatalf("parseTfvars: %v", err)
+	}
+	if vals["a"] != "hello" {
+		t.Fatalf("a=%v", vals["a"])
+	}
+	if v, _ := toFloat(vals["b"]); v != 42 {
+		t.Fatalf("b=%v", vals["b"])
+	}
+	if v, _ := toFloat(vals["c"]); v != -1.5 {
+		t.Fatalf("c=%v", vals["c"])
+	}
+	if vals["d"] != true {
+		t.Fatalf("d=%v", vals["d"])
+	}
+	list, ok := vals["e"].([]any)
+	if !ok || len(list) != 3 || list[0] != "x" || list[2] != false {
+		t.Fatalf("e=%v", vals["e"])
+	}
+	obj, ok := vals["f"].(map[string]any)
+	if !ok || obj["inner"] != "v" {
+		t.Fatalf("f=%v", vals["f"])
+	}
+	if vals["quoted"] != `escaped "quote" and \ slash` {
+		t.Fatalf("quoted=%q", vals["quoted"])
+	}
+}
+
+func TestParseTfvarsBadInput(t *testing.T) {
+	for _, src := range []string{
+		"a = \"unterminated\n",
+		"a = [1, 2\n",
+		"= 5\n",
+		"a = \n",
+		"a 5\n",
+	} {
+		if _, err := parseTfvars(src); err == nil {
+			t.Fatalf("expected error for input %q", src)
+		}
+	}
+}

--- a/worker/internal/execute/policy.go
+++ b/worker/internal/execute/policy.go
@@ -16,8 +16,8 @@ import (
 // ---------------------------------------------------------------------------
 
 type policyRule struct {
-	Enabled  bool   `json:"enabled"`
-	Severity string `json:"severity"`
+	Enabled     bool     `json:"enabled"`
+	Severity    string   `json:"severity"`
 	Enforcement string   `json:"enforcement"`
 	MaxDestroy  int      `json:"max_destroy"`
 	Types       []string `json:"types"`
@@ -27,8 +27,9 @@ type policyRule struct {
 }
 
 type policyConfig struct {
-	Mode  string                `json:"mode"` // warn | enforce
-	Rules map[string]policyRule `json:"rules"`
+	Mode        string                `json:"mode"` // warn | enforce
+	Rules       map[string]policyRule `json:"rules"`
+	CustomRules []customRule          `json:"custom_rules"`
 }
 
 type Violation struct {
@@ -49,6 +50,7 @@ type PolicyResult struct {
 	Blocked    bool        `json:"blocked"`
 	BlockedBy  []string    `json:"blocked_by,omitempty"`
 	Violations []Violation `json:"violations"`
+	Errors     []string    `json:"errors,omitempty"`
 }
 
 func parsePolicyConfig(raw any) *policyConfig {
@@ -66,12 +68,17 @@ func parsePolicyConfig(raw any) *policyConfig {
 	if cfg.Mode != "enforce" {
 		cfg.Mode = "warn"
 	}
-	if len(cfg.Rules) == 0 {
+	if len(cfg.Rules) == 0 && len(cfg.CustomRules) == 0 {
 		return nil
 	}
 	// Nothing enabled → treat as absent so we skip the whole gate.
 	for _, r := range cfg.Rules {
 		if r.Enabled {
+			return &cfg
+		}
+	}
+	for _, c := range cfg.CustomRules {
+		if c.Enabled {
 			return &cfg
 		}
 	}
@@ -90,7 +97,13 @@ type planResourceChange struct {
 }
 
 type planJSON struct {
-	ResourceChanges []planResourceChange `json:"resource_changes"`
+	ResourceChanges []planResourceChange        `json:"resource_changes"`
+	OutputChanges   map[string]planOutputChange `json:"output_changes"`
+}
+
+type planOutputChange struct {
+	Actions []string `json:"actions"`
+	After   any      `json:"after"`
 }
 
 // showPlanJSON runs `tofu show -json <planFile>` in stackDir.
@@ -142,8 +155,9 @@ func ruleBlocks(r policyRule, mode string) bool {
 	}
 }
 
-// evaluatePolicy applies the enabled rules to the plan JSON.
-func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
+// evaluatePolicy applies the enabled rules to the plan JSON. stackDir is used
+// only for custom rules targeting the rendered terraform.tfvars file.
+func evaluatePolicy(raw []byte, cfg *policyConfig, stackDir string) (*PolicyResult, error) {
 	var plan planJSON
 	if err := json.Unmarshal(raw, &plan); err != nil {
 		return nil, err
@@ -244,9 +258,12 @@ func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 			fmt.Sprintf("plan creates %d resources, above the limit of %d", created, r.Limit))
 	}
 
+	// --- custom rules -------------------------------------------------------
+	evaluateCustomRules(res, &plan, cfg, stackDir)
+
 	seenBlocked := map[string]bool{}
 	for _, v := range res.Violations {
-		if v.Severity == "deny" {
+		if v.Severity == "deny" || v.Severity == "error" {
 			res.Denies++
 		} else {
 			res.Warns++
@@ -398,7 +415,6 @@ func asInt(v any) (int, bool) {
 	return 0, false
 }
 
-
 func ruleCoversPort(rule map[string]any, p int) bool {
 	if proto, ok := rule["protocol"].(string); ok {
 		lp := strings.ToLower(strings.TrimSpace(proto))
@@ -457,8 +473,11 @@ func formatPolicyReport(res *PolicyResult) string {
 	}
 	for _, v := range res.Violations {
 		label := "WARN"
-		if v.Severity == "deny" {
+		switch v.Severity {
+		case "deny", "error":
 			label = "DENY"
+		case "info":
+			label = "INFO"
 		}
 		if v.Blocking {
 			label = "BLOCK"

--- a/worker/internal/execute/policy_test.go
+++ b/worker/internal/execute/policy_test.go
@@ -1,0 +1,130 @@
+package execute
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func samplePlanJSON(t *testing.T) []byte {
+	t.Helper()
+	plan := map[string]any{
+		"resource_changes": []map[string]any{
+			{
+				"address": "aws_security_group.web",
+				"type":    "aws_security_group",
+				"change": map[string]any{
+					"actions": []string{"create"},
+					"after": map[string]any{
+						"ingress": []map[string]any{
+							{"from_port": 22, "to_port": 22, "protocol": "tcp", "cidr_blocks": []string{"0.0.0.0/0"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	return b
+}
+
+func planConfig(t *testing.T, gateMode string, enforcement string) *policyConfig {
+	t.Helper()
+	raw := map[string]any{
+		"mode": gateMode,
+		"rules": map[string]any{
+			"deny_public_ingress": map[string]any{
+				"enabled":     true,
+				"severity":    "deny",
+				"enforcement": enforcement,
+				"ports":       []int{22},
+			},
+		},
+	}
+	cfg := parsePolicyConfig(raw)
+	if cfg == nil {
+		t.Fatalf("parsePolicyConfig returned nil")
+	}
+	return cfg
+}
+
+func TestPolicyDenyInheritBlocksOnlyInEnforce(t *testing.T) {
+	raw := samplePlanJSON(t)
+
+	// warn mode + deny + inherit -> reported, denies counted, but not blocking.
+	if res, err := evaluatePolicy(raw, planConfig(t, "warn", ""), ""); err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	} else if res.Blocked || res.Denies != 1 || len(res.BlockedBy) != 0 {
+		t.Fatalf("gate=warn inherit: got blocked=%v denies=%d blocked_by=%v", res.Blocked, res.Denies, res.BlockedBy)
+	}
+
+	// enforce mode + deny + inherit -> blocks.
+	if res, err := evaluatePolicy(raw, planConfig(t, "enforce", ""), ""); err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	} else if !res.Blocked || len(res.BlockedBy) != 1 || res.BlockedBy[0] != "deny_public_ingress" {
+		t.Fatalf("gate=enforce inherit: got blocked=%v blocked_by=%v", res.Blocked, res.BlockedBy)
+	}
+}
+
+func TestPolicyRuleLevelBlockAndReport(t *testing.T) {
+	raw := samplePlanJSON(t)
+
+	// rule-level block fires even when the gate runs in warn mode.
+	if res, err := evaluatePolicy(raw, planConfig(t, "warn", "block"), ""); err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	} else if !res.Blocked || len(res.BlockedBy) != 1 {
+		t.Fatalf("rule=block gate=warn: got blocked=%v blocked_by=%v", res.Blocked, res.BlockedBy)
+	}
+
+	// rule-level report never blocks, even in enforce mode.
+	if res, err := evaluatePolicy(raw, planConfig(t, "enforce", "report"), ""); err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	} else if res.Blocked || len(res.BlockedBy) != 0 {
+		t.Fatalf("rule=report gate=enforce: got blocked=%v blocked_by=%v", res.Blocked, res.BlockedBy)
+	}
+}
+
+func TestPolicyViolationCarriesBlockingInfo(t *testing.T) {
+	raw := samplePlanJSON(t)
+	res, err := evaluatePolicy(raw, planConfig(t, "warn", "block"), "")
+	if err != nil {
+		t.Fatalf("evaluatePolicy: %v", err)
+	}
+	if len(res.Violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(res.Violations))
+	}
+	if !res.Violations[0].Blocking || res.Violations[0].Rule != "deny_public_ingress" {
+		t.Fatalf("violation missing blocking info: %+v", res.Violations[0])
+	}
+}
+
+func TestParsePolicyConfigWithOnlyCustomRules(t *testing.T) {
+	raw := map[string]any{
+		"mode": "warn",
+		"custom_rules": []map[string]any{{
+			"id": "c1", "enabled": true, "severity": "error",
+			"checks": []map[string]any{{"path": "a", "operator": "exists"}},
+		}},
+	}
+	if cfg := parsePolicyConfig(raw); cfg == nil {
+		t.Fatalf("parsePolicyConfig returned nil for enabled custom rule")
+	}
+}
+
+func TestParsePolicyConfigDisabledRulesIsNil(t *testing.T) {
+	raw := map[string]any{
+		"mode": "enforce",
+		"rules": map[string]any{
+			"deny_destroy": map[string]any{"enabled": false},
+		},
+		"custom_rules": []map[string]any{{
+			"id": "c1", "enabled": false, "severity": "error",
+			"checks": []map[string]any{{"path": "a", "operator": "exists"}},
+		}},
+	}
+	if cfg := parsePolicyConfig(raw); cfg != nil {
+		t.Fatalf("parsePolicyConfig should return nil when nothing is enabled")
+	}
+}

--- a/worker/internal/execute/tofu.go
+++ b/worker/internal/execute/tofu.go
@@ -387,7 +387,7 @@ func executeTofuRun(executionID string, execData map[string]any, projectID strin
 			returnCode = &rc
 			return
 		}
-		res, eerr := evaluatePolicy(raw, policyCfg)
+		res, eerr := evaluatePolicy(raw, policyCfg, stackDir)
 		if eerr != nil {
 			sendLog("[policy] ERROR: could not parse plan JSON: " + eerr.Error() + " — aborting.\n")
 			rc := 1
@@ -530,7 +530,7 @@ loop:
 	// written, so the only extra work is one local `tofu show -json`.
 	if policyCfg != nil && strings.EqualFold(action, "plan") && finalStatus == "SUCCESS" && !killed {
 		if raw, serr := showPlanJSON(stackDir, "tfplan", env); serr == nil {
-			if res, eerr := evaluatePolicy(raw, policyCfg); eerr == nil {
+			if res, eerr := evaluatePolicy(raw, policyCfg, stackDir); eerr == nil {
 				policyRes = res
 				sendLog(formatPolicyReport(res))
 				if res.Blocked {


### PR DESCRIPTION
## What

Adds **custom policy rules** to the Policy-as-Code gate, complementing the existing built-in rules (`deny_destroy`, `denied_resource_types`, `require_tags`, `deny_public_ingress`, `max_created`).

A custom rule is defined declaratively in the stack policy config and runs on the worker against the `tofu show -json` plan:

```yaml
- id: no_public_buckets
  name: No public buckets
  enabled: true
  severity: error        # info | warning | error
  enforcement: block     # inherit | block | report
  target: resource       # resource | output | config
  match:
    types: [aws_s3_bucket]
    actions: [create, update]
  checks:
    - path: acl
      operator: not_equals
      value: public-read
```

## Behavior

- **Severities** — `info` (report only, can never block), `warning` (blocks only in enforce mode), `error` (deny-equivalent).
- **Per-rule enforcement** — `inherit`/`block`/`report` applies to both built-in and custom rules. Gate `mode` (warn/enforce) still governs built-in `inherit` rules.
- **Targets** — `resource` (plan `resource_changes`), `output` (plan `output_changes`), `config` (rendered `terraform.tfvars`).
- **Check DSL** — 12 operators (`exists`, `not_exists`, `equals`, `not_equals`, `contains`, `not_contains`, `matches`, `not_matches`, `gt`, `gte`, `lt`, `lte`) evaluated with RE2 regex; invalid patterns surface in the result `errors` field, so a broken rule never silently passes or blocks.
- Custom rules count toward `denies`/`warns`, are listed in `blocked_by` when blocking, and appear in the worker log report.

## Server (`services/cloud_policy.py`)

- Whitelisting sanitizer `sanitize_custom_rules` (id/severity/enforcement/target/match/checks schema, dedup by id, limits).
- `custom_rules` added to `default_policy`, `policy_config_from_meta`, and `sanitize_policy`.
- `last_result` now includes `errors`.

## Worker (`internal/execute`)

- `policy.go`: custom rules wired into config parse, `evaluatePolicy(raw, cfg, stackDir)`, severity counting, report labels (`DENY`/`WARN`/`INFO`/`BLOCK`).
- `custom.go`: rule matching + check evaluation engine.
- `tofu.go`: plan/apply gate paths pass `stackDir` for config-target rules.

## Tests

- `custom_test.go`: custom rules across severities, enforcements, targets, operators, invalid-regex handling.
- `policy_test.go`: gate-mode vs per-rule enforcement semantics, deny counting, violation blocking info.
- Server functions verified with unit checks (flask stubbed); worker `go build`/`go vet`/`go test` clean.