### PR TITLE
feat: enhance Policy-as-Code with custom rules and enforcement UX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,14 @@ OpenSible is built by and for the community. We believe that open collaboration 
 ### How to contribute
 We follow the standard GitHub fork-and-pull-request model for all contributions.
 
-1. **Find an issue**: Look for issues labeled "good first issue" or "help wanted" on our GitHub tracker.
-2. **Fork the repo**: Create a fork of the OpenSible repository in your own GitHub account.
-3. **Branching**: Create a new branch for your work (e.g., `feature/new-aws-stack` or `fix/worker-log-caching`).
-4. **Develop**: Make your changes. If you are adding code, please ensure you also add relevant tests.
-5. **Lint and Test**: Run our automated linting and test suites to ensure your changes don't break existing functionality.
-6. **Pull Request**: Open a PR against our `develop` branch. Provide a clear description of what your PR does and why it is needed.
-7. **Code Review**: A maintainer will review your PR. Be prepared to make adjustments based on their feedback.
+1. **Create or discuss an issue**: Before starting any implementation, create an issue describing the proposed change, feature, or improvement. Discuss the potential implementation and approach with the maintainers and wait for confirmation before starting work.
+2. **Find an issue**: Look for issues labeled "good first issue" or "help wanted" on our GitHub tracker.
+3. **Fork the repo**: Create a fork of the OpenSible repository in your own GitHub account.
+4. **Branching**: Create a new branch for your work (e.g., `feature/new-aws-stack` or `fix/worker-log-caching`).
+5. **Develop**: Make your changes. If you are adding code, please ensure you also add relevant tests.
+6. **Lint and Test**: Run our automated linting and test suites to ensure your changes don't break existing functionality.
+7. **Pull Request**: Open a PR against our `develop` branch. Provide a clear description of what your PR does and why it is needed.
+8. **Code Review**: A maintainer will review your PR. Be prepared to make adjustments based on their feedback.
 
 ### Developer resources
 *   **Local setup**: See the [Developer Guide](../) for detailed instructions on setting up your environment.

--- a/console/src/components/cloud/CustomPolicyRules.tsx
+++ b/console/src/components/cloud/CustomPolicyRules.tsx
@@ -1,0 +1,478 @@
+/**
+ * Custom (user-defined) policy rules editor.
+ */
+import { useMemo, useState } from "react";
+import * as yaml from "js-yaml";
+import { Plus, Trash2, Code2, ListChecks, FileWarning } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { YamlEditor } from "@/components/ui/yaml-editor";
+
+export type CustomSeverity = "info" | "warn" | "deny";
+export type Enforcement = "inherit" | "block" | "report";
+
+export type CustomRule = {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  severity: CustomSeverity;
+  enforcement?: Enforcement;
+  resource_types?: string[];
+  addresses?: string[];
+  actions?: string[];
+  attribute?: string;
+  operator?: string;
+  value?: string;
+  message?: string;
+};
+
+export const CUSTOM_OPERATORS: Array<{ value: string; label: string; description: string }> = [
+  { value: "matches", label: "matches regex", description: "Violation when the attribute matches the pattern" },
+  { value: "not_matches", label: "does not match regex", description: "Violation when the attribute fails the pattern" },
+  { value: "equals", label: "equals", description: "Violation when the attribute equals the value" },
+  { value: "not_equals", label: "does not equal", description: "Violation when the attribute differs from the value" },
+  { value: "exists", label: "must be set", description: "Violation when the attribute is missing" },
+  { value: "not_exists", label: "must not be set", description: "Violation when the attribute is present" },
+  { value: "gt", label: "greater than", description: "Numeric comparison" },
+  { value: "lt", label: "less than", description: "Numeric comparison" },
+];
+
+const ACTION_OPTIONS = ["create", "update", "delete", "no-op"];
+
+export const EXAMPLE_RULES_YAML = `# One entry per rule. Regex is Go RE2 syntax.
+- id: no-public-buckets
+  name: No public object storage
+  description: Object storage must not be world readable.
+  enabled: true
+  severity: deny          # info | warn | deny
+  enforcement: inherit    # inherit | block | report
+  resource_types: ["^aws_s3_bucket.*", "^google_storage_bucket$"]
+  actions: [create, update]
+  attribute: acl
+  operator: matches
+  value: "public"
+  message: Bucket ACL must not be public.
+
+- id: instance-naming
+  name: Instance names must follow the naming standard
+  enabled: true
+  severity: warn
+  resource_types: ["^hcloud_server$", "^aws_instance$"]
+  attribute: name
+  operator: not_matches
+  value: "^(dev|stg|prd)-[a-z0-9-]+$"
+  message: Name must look like prd-web-01.
+
+- id: ingress-cidr-audit
+  name: Audit wide-open ingress CIDRs
+  enabled: false
+  severity: info
+  attribute: "ingress.*.cidr_blocks"
+  operator: matches
+  value: "^0\\\\.0\\\\.0\\\\.0/0$"
+`;
+
+function slugify(v: string, fallback: string) {
+  const s = v
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return s || fallback;
+}
+
+function listToText(v?: string[]) {
+  return (v || []).join(", ");
+}
+
+function textToList(s: string) {
+  return s
+    .split(",")
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+export function normalizeCustomRules(input: unknown): CustomRule[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  return input.slice(0, 100).flatMap((raw: any, i): CustomRule[] => {
+    if (!raw || typeof raw !== "object") return [];
+    const name = String(raw.name ?? raw.id ?? "").trim();
+    let id = slugify(String(raw.id ?? name), `rule-${i + 1}`);
+    let n = 2;
+    while (seen.has(id)) id = `${slugify(String(raw.id ?? name), `rule-${i + 1}`)}-${n++}`;
+    seen.add(id);
+    const sev = ["info", "warn", "deny"].includes(raw.severity) ? raw.severity : "warn";
+    const enf = ["inherit", "block", "report"].includes(raw.enforcement) ? raw.enforcement : "inherit";
+    const asList = (v: any) => (typeof v === "string" ? [v] : Array.isArray(v) ? v.map(String) : []);
+    return [
+      {
+        id,
+        name: name || id,
+        description: raw.description ? String(raw.description) : "",
+        enabled: raw.enabled !== false,
+        severity: sev,
+        enforcement: enf,
+        resource_types: asList(raw.resource_types),
+        addresses: asList(raw.addresses),
+        actions: asList(raw.actions).filter((a) => ACTION_OPTIONS.includes(a)),
+        attribute: raw.attribute ? String(raw.attribute) : "",
+        operator: CUSTOM_OPERATORS.some((o) => o.value === raw.operator) ? String(raw.operator) : "matches",
+        value: raw.value !== undefined && raw.value !== null ? String(raw.value) : String(raw.pattern ?? ""),
+        message: raw.message ? String(raw.message) : "",
+      },
+    ];
+  });
+}
+
+/** Compile-check every regex field so users see mistakes before saving. */
+export function ruleRegexErrors(rule: CustomRule): string[] {
+  const errs: string[] = [];
+  const check = (pattern: string, where: string) => {
+    try {
+      new RegExp(pattern);
+    } catch (e: any) {
+      errs.push(`${where}: ${e?.message || "invalid regex"}`);
+    }
+  };
+  (rule.resource_types || []).forEach((p) => check(p, `resource type /${p}/`));
+  (rule.addresses || []).forEach((p) => check(p, `address /${p}/`));
+  if ((rule.operator === "matches" || rule.operator === "not_matches") && rule.value) {
+    check(rule.value, `pattern /${rule.value}/`);
+  }
+  return errs;
+}
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors"
+      style={{ background: checked ? "var(--color-primary)" : "var(--color-muted)" }}
+    >
+      <span
+        className="inline-block h-5 w-5 rounded-full bg-[var(--color-background)] shadow transition-transform"
+        style={{ transform: checked ? "translateX(22px)" : "translateX(2px)" }}
+      />
+    </button>
+  );
+}
+
+function sevVariant(sev: CustomSeverity) {
+  return sev === "deny" ? "destructive" : sev === "warn" ? "warning" : "primary";
+}
+
+export function CustomPolicyRules({
+  rules,
+  mode,
+  onChange,
+}: {
+  rules: CustomRule[];
+  mode: "warn" | "enforce";
+  onChange: (next: CustomRule[]) => void;
+}) {
+  const [view, setView] = useState<"form" | "yaml">("form");
+  const [yamlText, setYamlText] = useState<string>("");
+  const [yamlError, setYamlError] = useState<string | null>(null);
+
+  const errors = useMemo(
+    () => rules.flatMap((r) => ruleRegexErrors(r).map((e) => `${r.name}: ${e}`)),
+    [rules],
+  );
+
+  const openYaml = () => {
+    setYamlError(null);
+    setYamlText(rules.length ? yaml.dump(rules, { lineWidth: 1000, noRefs: true }) : EXAMPLE_RULES_YAML);
+    setView("yaml");
+  };
+
+  const applyYaml = () => {
+    try {
+      const parsed = yaml.load(yamlText);
+      if (parsed != null && !Array.isArray(parsed)) {
+        setYamlError("The document must be a list of rules (start each rule with '- ').");
+        return;
+      }
+      onChange(normalizeCustomRules(parsed || []));
+      setYamlError(null);
+      setView("form");
+    } catch (e: any) {
+      setYamlError(e?.message || "Could not parse the YAML.");
+    }
+  };
+
+  const patch = (id: string, p: Partial<CustomRule>) =>
+    onChange(rules.map((r) => (r.id === id ? { ...r, ...p } : r)));
+
+  const addRule = () => {
+    let base = "custom-rule";
+    let id = base;
+    let n = 2;
+    while (rules.some((r) => r.id === id)) id = `${base}-${n++}`;
+    onChange([
+      ...rules,
+      {
+        id,
+        name: "New rule",
+        description: "",
+        enabled: true,
+        severity: "warn",
+        enforcement: "inherit",
+        resource_types: [],
+        addresses: [],
+        actions: [],
+        attribute: "",
+        operator: "matches",
+        value: "",
+        message: "",
+      },
+    ]);
+  };
+
+  const blocksRun = (r: CustomRule) =>
+    r.enforcement === "block" || (r.enforcement !== "report" && r.severity === "deny" && mode === "enforce");
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div className="text-sm font-medium">Custom rules</div>
+          <p className="text-xs text-[var(--color-muted-foreground)] max-w-2xl">
+            Your own organisation-specific checks. Target resources by type or address with regex, then assert
+            something about a planned attribute. Author them here or paste YAML.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {view === "form" ? (
+            <>
+              <Button size="sm" variant="secondary" onClick={openYaml}>
+                <Code2 className="h-4 w-4 mr-1.5" /> Edit as YAML
+              </Button>
+              <Button size="sm" variant="secondary" onClick={addRule}>
+                <Plus className="h-4 w-4 mr-1.5" /> Add rule
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button size="sm" variant="secondary" onClick={() => setView("form")}>
+                <ListChecks className="h-4 w-4 mr-1.5" /> Back to list
+              </Button>
+              <Button size="sm" onClick={applyYaml}>
+                Apply YAML
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {view === "yaml" ? (
+        <div className="space-y-2">
+          <YamlEditor value={yamlText} onChange={setYamlText} height={340} />
+          {yamlError && (
+            <p className="text-xs text-[var(--color-destructive)] flex items-center gap-1.5">
+              <FileWarning className="h-3.5 w-3.5" /> {yamlError}
+            </p>
+          )}
+          <p className="text-xs text-[var(--color-muted-foreground)]">
+            Fields: <code className="font-mono">id, name, description, enabled, severity (info|warn|deny),
+            enforcement (inherit|block|report), resource_types[], addresses[], actions[], attribute, operator,
+            value, message</code>. Attribute paths support nesting and wildcards, e.g.{" "}
+            <code className="font-mono">ingress.*.cidr_blocks</code>.
+          </p>
+          <Button size="sm" variant="ghost" onClick={() => setYamlText(EXAMPLE_RULES_YAML)}>
+            Load examples
+          </Button>
+        </div>
+      ) : rules.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-[var(--color-border)] p-4 text-sm text-[var(--color-muted-foreground)]">
+          No custom rules yet. Add one, or paste a YAML rule pack.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {rules.map((r) => {
+            const regexErrs = ruleRegexErrors(r);
+            const needsValue = !["exists", "not_exists"].includes(r.operator || "matches");
+            return (
+              <div key={r.id} className="rounded-xl border border-[var(--color-border)] p-3 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        className="w-full sm:w-72"
+                        value={r.name}
+                        placeholder="Rule name"
+                        onChange={(e) => patch(r.id, { name: e.target.value })}
+                      />
+                      <Badge variant={sevVariant(r.severity)}>{r.severity.toUpperCase()}</Badge>
+                      {r.enabled &&
+                        (blocksRun(r) ? (
+                          <Badge variant="destructive">Blocks run</Badge>
+                        ) : (
+                          <Badge variant="default">Reports only</Badge>
+                        ))}
+                      <code className="text-xs font-mono text-[var(--color-muted-foreground)]">{r.id}</code>
+                    </div>
+                    <Input
+                      className="w-full"
+                      value={r.description || ""}
+                      placeholder="What this rule protects against (optional)"
+                      onChange={(e) => patch(r.id, { description: e.target.value })}
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Toggle
+                      checked={r.enabled}
+                      label={`Toggle ${r.name}`}
+                      onChange={(v) => patch(r.id, { enabled: v })}
+                    />
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      aria-label={`Delete ${r.name}`}
+                      onClick={() => onChange(rules.filter((x) => x.id !== r.id))}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <label className="text-xs space-y-1">
+                    <span className="text-[var(--color-muted-foreground)]">
+                      Resource types (regex, comma separated — empty = any)
+                    </span>
+                    <Input
+                      placeholder="^aws_s3_bucket$, ^hcloud_.*"
+                      value={listToText(r.resource_types)}
+                      onChange={(e) => patch(r.id, { resource_types: textToList(e.target.value) })}
+                    />
+                  </label>
+                  <label className="text-xs space-y-1">
+                    <span className="text-[var(--color-muted-foreground)]">
+                      Addresses (regex, comma separated — empty = any)
+                    </span>
+                    <Input
+                      placeholder="^module\\.network\\..*"
+                      value={listToText(r.addresses)}
+                      onChange={(e) => patch(r.id, { addresses: textToList(e.target.value) })}
+                    />
+                  </label>
+                  <label className="text-xs space-y-1">
+                    <span className="text-[var(--color-muted-foreground)]">
+                      Attribute path (empty = whole resource)
+                    </span>
+                    <Input
+                      placeholder="tags.owner or ingress.*.cidr_blocks"
+                      value={r.attribute || ""}
+                      onChange={(e) => patch(r.id, { attribute: e.target.value })}
+                    />
+                  </label>
+                  <label className="text-xs space-y-1">
+                    <span className="text-[var(--color-muted-foreground)]">
+                      Plan actions (empty = create &amp; update)
+                    </span>
+                    <Input
+                      placeholder="create, update"
+                      value={listToText(r.actions)}
+                      onChange={(e) =>
+                        patch(r.id, {
+                          actions: textToList(e.target.value).filter((a) => ACTION_OPTIONS.includes(a)),
+                        })
+                      }
+                    />
+                  </label>
+                </div>
+
+                <div className="flex flex-wrap items-end gap-2">
+                  <div className="w-52">
+                    <span className="text-xs text-[var(--color-muted-foreground)]">Condition</span>
+                    <Select
+                      value={r.operator || "matches"}
+                      onChange={(v) => patch(r.id, { operator: v })}
+                      options={CUSTOM_OPERATORS}
+                    />
+                  </div>
+                  {needsValue && (
+                    <label className="text-xs space-y-1 flex-1 min-w-[12rem]">
+                      <span className="text-[var(--color-muted-foreground)]">
+                        {r.operator === "matches" || r.operator === "not_matches" ? "Pattern (regex)" : "Value"}
+                      </span>
+                      <Input
+                        placeholder={r.operator === "gt" || r.operator === "lt" ? "10" : "^prd-"}
+                        value={r.value || ""}
+                        onChange={(e) => patch(r.id, { value: e.target.value })}
+                      />
+                    </label>
+                  )}
+                  <div className="w-32">
+                    <span className="text-xs text-[var(--color-muted-foreground)]">Severity</span>
+                    <Select
+                      value={r.severity}
+                      onChange={(v) => patch(r.id, { severity: v as CustomSeverity })}
+                      options={[
+                        { value: "info", label: "Info", description: "Informational only" },
+                        { value: "warn", label: "Warn", description: "Reported as a warning" },
+                        { value: "deny", label: "Deny", description: "Counts as a violation" },
+                      ]}
+                    />
+                  </div>
+                  <div className="w-48">
+                    <span className="text-xs text-[var(--color-muted-foreground)]">Enforcement</span>
+                    <Select
+                      value={r.enforcement || "inherit"}
+                      onChange={(v) => patch(r.id, { enforcement: v as Enforcement })}
+                      options={[
+                        { value: "inherit", label: "Follow gate mode", description: "Blocks only in enforce mode" },
+                        { value: "block", label: "Always block", description: "Blocks even in warn mode" },
+                        { value: "report", label: "Never block", description: "Only reports" },
+                      ]}
+                    />
+                  </div>
+                </div>
+
+                <label className="text-xs space-y-1 block">
+                  <span className="text-[var(--color-muted-foreground)]">
+                    Message shown on a violation (optional)
+                  </span>
+                  <Input
+                    placeholder="Buckets must not be public."
+                    value={r.message || ""}
+                    onChange={(e) => patch(r.id, { message: e.target.value })}
+                  />
+                </label>
+
+                {regexErrs.length > 0 && (
+                  <p className="text-xs text-[var(--color-destructive)] flex items-start gap-1.5">
+                    <FileWarning className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    <span>{regexErrs.join("; ")}</span>
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {view === "form" && errors.length > 0 && (
+        <p className="text-xs text-[var(--color-destructive)]">
+          Fix the invalid regex above — rules that fail to compile are dropped when saved.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/console/src/components/cloud/PlanDiff.tsx
+++ b/console/src/components/cloud/PlanDiff.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from "react";
-import { ChevronRight, FilePlus2, FileMinus2, FileDiff, RefreshCcwDot, Eye, CheckCircle2 } from "lucide-react";
+import { ChevronRight, FilePlus2, FileMinus2, FileDiff, RefreshCcwDot, Eye, CheckCircle2, ShieldCheck, ShieldAlert, ShieldX } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { parseTofuPlan, ACTION_META, type PlanChangeAction, type PlanResource } from "@/lib/tofu-plan";
+import { parseTofuPlan, ACTION_META, type PlanChangeAction, type PlanResource, type PolicyReport } from "@/lib/tofu-plan";
 import { cn } from "@/lib/utils";
 
 const TONE_CLASS: Record<string, string> = {
@@ -84,6 +84,71 @@ function Stat({ value, label, tone }: { value: number; label: string; tone: stri
   );
 }
 
+function PolicySection({ policy }: { policy: PolicyReport }) {
+  const Icon = policy.blocked ? ShieldX : policy.violations.length ? ShieldAlert : ShieldCheck;
+  const tone = policy.blocked
+    ? TONE_CLASS.destroy
+    : policy.violations.length
+      ? TONE_CLASS.update
+      : TONE_CLASS.create;
+  return (
+    <div className="rounded-md border border-[var(--color-border)]">
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-[var(--color-border)]">
+        <Icon className={cn("h-4 w-4", tone)} />
+        <span className="text-xs font-medium">Policy-as-code gate</span>
+        <Badge variant="default" className="text-[10px]">mode: {policy.mode}</Badge>
+        {policy.blocked ? (
+          <Badge variant="destructive" className="text-[10px]">Run blocked</Badge>
+        ) : policy.violations.length ? (
+          <Badge variant="warning" className="text-[10px]">Violations reported</Badge>
+        ) : (
+          <Badge variant="success" className="text-[10px]">Passed</Badge>
+        )}
+        <span className="ml-auto text-[11px] text-[var(--color-muted-foreground)] tabular-nums">
+          {policy.denies} deny · {policy.warns} warn
+        </span>
+      </div>
+
+      {policy.blocked && policy.blockedBy.length > 0 && (
+        <div className="px-3 py-2 text-[11px] border-b border-[var(--color-border)]">
+          <span className="text-[var(--color-muted-foreground)]">Blocked by: </span>
+          <span className={cn("font-mono", TONE_CLASS.destroy)}>{policy.blockedBy.join(", ")}</span>
+        </div>
+      )}
+
+      {policy.violations.length > 0 ? (
+        <div className="divide-y divide-[var(--color-border)]">
+          {policy.violations.map((v, i) => (
+            <div key={`${v.rule}-${i}`} className="flex flex-wrap items-start gap-2 px-3 py-2">
+              <span
+                className={cn(
+                  "text-[10px] font-semibold uppercase tracking-wide rounded px-1.5 py-0.5 shrink-0",
+                  v.level === "warn" ? TONE_CLASS.update : TONE_CLASS.destroy
+                )}
+              >
+                {v.level}
+              </span>
+              <span className="font-mono text-[11px] shrink-0">{v.rule}</span>
+              {v.address && (
+                <span className="font-mono text-[11px] text-[var(--color-muted-foreground)] truncate">
+                  {v.address}
+                </span>
+              )}
+              <span className="text-[11px] basis-full sm:basis-auto sm:flex-1 text-[var(--color-muted-foreground)]">
+                {v.message}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="px-3 py-2 text-[11px] text-[var(--color-muted-foreground)]">
+          No policy violations found.
+        </p>
+      )}
+    </div>
+  );
+}
+
 export function PlanDiff({
   log,
   action,
@@ -133,6 +198,8 @@ export function PlanDiff({
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        {parsed.policy && <PolicySection policy={parsed.policy} />}
+
         {isDrift && parsed.driftDetected && parsed.resources.length === 0 && (
           <p className="text-xs text-[var(--color-muted-foreground)]">
             The live infrastructure differs from the recorded state. No managed resource blocks were

--- a/console/src/components/cloud/PolicyGateCard.tsx
+++ b/console/src/components/cloud/PolicyGateCard.tsx
@@ -1,5 +1,6 @@
 /**
  * Policy-as-code gate panel for a single Cloud stack.
+ *
  */
 import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -10,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import { CustomPolicyRules, type CustomRule } from "@/components/cloud/CustomPolicyRules";
 import { api } from "@/lib/api";
 
 type Severity = "warn" | "deny";
@@ -29,11 +31,13 @@ type Rule = {
 type PolicyConfig = {
   mode: "warn" | "enforce";
   rules: Record<string, Rule>;
+  custom_rules?: CustomRule[];
 };
 
 type Violation = {
   rule: string;
-  severity: Severity;
+  name?: string;
+  severity: Severity | "info";
   blocking?: boolean;
   address?: string;
   type?: string;
@@ -47,6 +51,7 @@ type LastResult = {
   verdict?: "pass" | "warn" | "fail" | string;
   denies?: number;
   warns?: number;
+  infos?: number;
   blocked?: boolean;
   blocked_by?: string[];
   violations?: Violation[];
@@ -57,6 +62,7 @@ type PolicyResp = {
   policy: PolicyConfig;
   last_result: LastResult;
 };
+
 
 const RULE_META: Record<string, { title: string; help: string }> = {
   deny_destroy: {
@@ -129,6 +135,11 @@ function textToList(s: string) {
     .map((x) => x.trim())
     .filter(Boolean);
 }
+function ruleLabel(key: string) {
+  if (key?.startsWith("custom:")) return key.slice("custom:".length);
+  return RULE_META[key]?.title || key;
+}
+
 
 /** Does this rule stop a run, given the gate-level mode? */
 function ruleBlocks(rule: Rule, mode: PolicyConfig["mode"]) {
@@ -396,6 +407,19 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
               })}
             </div>
 
+            <div className="h-px bg-[var(--color-border)]" />
+
+            <CustomPolicyRules
+              rules={draft.custom_rules || []}
+              mode={draft.mode}
+              onChange={(next) => {
+                setDirty(true);
+                setDraft({ ...draft, custom_rules: next });
+              }}
+            />
+
+
+
             <div className="flex items-center gap-3">
               <Button
                 size="sm"
@@ -421,19 +445,34 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
                 </div>
                 {last.blocked && (last.blocked_by || []).length > 0 && (
                   <p className="mt-1 text-xs text-[var(--color-destructive)]">
-                    Run blocked by: {(last.blocked_by || []).map((r) => RULE_META[r]?.title || r).join(", ")}
+                    Run blocked by: {(last.blocked_by || []).map(ruleLabel).join(", ")}
                   </p>
                 )}
                 {last.violations && last.violations.length > 0 ? (
                   <ul className="mt-2 space-y-1">
                     {last.violations.slice(0, 25).map((v, i) => (
                       <li key={i} className="text-xs flex flex-wrap items-baseline gap-2">
-                        <Badge variant={v.blocking || v.severity === "deny" ? "destructive" : "warning"}>
-                          {v.blocking ? "BLOCK" : v.severity === "deny" ? "DENY" : "WARN"}
+                        <Badge
+                          variant={
+                            v.blocking || v.severity === "deny"
+                              ? "destructive"
+                              : v.severity === "info"
+                              ? "primary"
+                              : "warning"
+                          }
+                        >
+                          {v.blocking
+                            ? "BLOCK"
+                            : v.severity === "deny"
+                            ? "DENY"
+                            : v.severity === "info"
+                            ? "INFO"
+                            : "WARN"}
                         </Badge>
                         <span className="text-[var(--color-muted-foreground)]">
-                          {RULE_META[v.rule]?.title || v.rule}
+                          {v.name || ruleLabel(v.rule)}
                         </span>
+
                         <code className="font-mono">{v.address || "plan"}</code>
                         <span className="text-[var(--color-muted-foreground)]">{v.message}</span>
                       </li>

--- a/console/src/components/cloud/PolicyGateCard.tsx
+++ b/console/src/components/cloud/PolicyGateCard.tsx
@@ -13,10 +13,12 @@ import { Select } from "@/components/ui/select";
 import { api } from "@/lib/api";
 
 type Severity = "warn" | "deny";
+type Enforcement = "inherit" | "block" | "report";
 
 type Rule = {
   enabled: boolean;
   severity: Severity;
+  enforcement?: Enforcement;
   max_destroy?: number;
   types?: string[];
   keys?: string[];
@@ -32,6 +34,7 @@ type PolicyConfig = {
 type Violation = {
   rule: string;
   severity: Severity;
+  blocking?: boolean;
   address?: string;
   type?: string;
   message: string;
@@ -44,6 +47,8 @@ type LastResult = {
   verdict?: "pass" | "warn" | "fail" | string;
   denies?: number;
   warns?: number;
+  blocked?: boolean;
+  blocked_by?: string[];
   violations?: Violation[];
 } | null;
 
@@ -123,6 +128,14 @@ function textToList(s: string) {
     .split(",")
     .map((x) => x.trim())
     .filter(Boolean);
+}
+
+/** Does this rule stop a run, given the gate-level mode? */
+function ruleBlocks(rule: Rule, mode: PolicyConfig["mode"]) {
+  const enf = rule.enforcement || "inherit";
+  if (enf === "block") return true;
+  if (enf === "report") return false;
+  return rule.severity === "deny" && mode === "enforce";
 }
 
 export function PolicyGateCard({ stackId }: { stackId: string }) {
@@ -236,8 +249,8 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
               <span className="text-xs text-[var(--color-muted-foreground)] flex items-center gap-1">
                 <Info className="h-3.5 w-3.5" />
                 {draft.mode === "enforce"
-                  ? "Apply and destroy are blocked when a deny-severity rule fires."
-                  : "Violations are reported in the run log only."}
+                  ? "Deny-severity rules block the run unless a rule overrides it."
+                  : "Rules only report — unless a rule is set to \u201cAlways block\u201d."}
               </span>
             </div>
 
@@ -249,16 +262,18 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
                 return (
                   <div
                     key={id}
-                    className="rounded-xl border border-[var(--color-border)] p-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+                    className="rounded-xl border border-[var(--color-border)] p-3 flex flex-col gap-3"
                   >
-                    <div className="min-w-0">
-                      <div className="text-sm font-medium flex items-center gap-2">
-                        {meta.title}
-                        {rule.enabled && (
-                          <Badge variant={rule.severity === "deny" ? "destructive" : "warning"}>
-                            {rule.severity === "deny" ? "Deny" : "Warn"}
-                          </Badge>
-                        )}
+                    <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium flex flex-wrap items-center gap-2">
+                        <span className="break-words">{meta.title}</span>
+                        {rule.enabled &&
+                          (ruleBlocks(rule, draft.mode) ? (
+                            <Badge variant="destructive">Blocks run</Badge>
+                          ) : (
+                            <Badge variant="warning">Reports only</Badge>
+                          ))}
                       </div>
                       <p className="text-xs text-[var(--color-muted-foreground)] mt-0.5">{meta.help}</p>
 
@@ -332,10 +347,16 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
                         </div>
                       )}
                     </div>
+                      <Toggle
+                        checked={rule.enabled}
+                        label={`Toggle ${meta.title}`}
+                        onChange={(v) => patchRule(id, { enabled: v })}
+                      />
+                    </div>
 
-                    <div className="flex items-center gap-3 shrink-0">
-                      {rule.enabled && (
-                        <div className="w-28">
+                    {rule.enabled && (
+                      <div className="flex flex-wrap items-center gap-3">
+                        <div className="w-32">
                           <Select
                             value={rule.severity}
                             onChange={(v) => patchRule(id, { severity: v as Severity })}
@@ -345,13 +366,31 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
                             ]}
                           />
                         </div>
-                      )}
-                      <Toggle
-                        checked={rule.enabled}
-                        label={`Toggle ${meta.title}`}
-                        onChange={(v) => patchRule(id, { enabled: v })}
-                      />
-                    </div>
+                        <div className="w-48">
+                          <Select
+                            value={rule.enforcement || "inherit"}
+                            onChange={(v) => patchRule(id, { enforcement: v as Enforcement })}
+                            options={[
+                              {
+                                value: "inherit",
+                                label: "Follow gate mode",
+                                description: "Blocks only when the gate is in enforce mode",
+                              },
+                              {
+                                value: "block",
+                                label: "Always block",
+                                description: "Blocks the run even while the gate is in warn mode",
+                              },
+                              {
+                                value: "report",
+                                label: "Never block",
+                                description: "Only reports, even while the gate is in enforce mode",
+                              },
+                            ]}
+                          />
+                        </div>
+                      </div>
+                    )}
                   </div>
                 );
               })}
@@ -380,13 +419,21 @@ export function PolicyGateCard({ stackId }: { stackId: string }) {
                     from {last.action || "run"}
                   </span>
                 </div>
+                {last.blocked && (last.blocked_by || []).length > 0 && (
+                  <p className="mt-1 text-xs text-[var(--color-destructive)]">
+                    Run blocked by: {(last.blocked_by || []).map((r) => RULE_META[r]?.title || r).join(", ")}
+                  </p>
+                )}
                 {last.violations && last.violations.length > 0 ? (
                   <ul className="mt-2 space-y-1">
                     {last.violations.slice(0, 25).map((v, i) => (
                       <li key={i} className="text-xs flex flex-wrap items-baseline gap-2">
-                        <Badge variant={v.severity === "deny" ? "destructive" : "warning"}>
-                          {v.severity === "deny" ? "DENY" : "WARN"}
+                        <Badge variant={v.blocking || v.severity === "deny" ? "destructive" : "warning"}>
+                          {v.blocking ? "BLOCK" : v.severity === "deny" ? "DENY" : "WARN"}
                         </Badge>
+                        <span className="text-[var(--color-muted-foreground)]">
+                          {RULE_META[v.rule]?.title || v.rule}
+                        </span>
                         <code className="font-mono">{v.address || "plan"}</code>
                         <span className="text-[var(--color-muted-foreground)]">{v.message}</span>
                       </li>

--- a/console/src/lib/tofu-plan.ts
+++ b/console/src/lib/tofu-plan.ts
@@ -31,11 +31,29 @@ export type PlanSummary = {
   applied: boolean;
 };
 
+export type PolicyViolation = {
+  level: "warn" | "deny" | "block";
+  rule: string;
+  address: string;
+  message: string;
+};
+
+export type PolicyReport = {
+  mode: string;
+  denies: number;
+  warns: number;
+  passed: boolean;
+  blocked: boolean;
+  blockedBy: string[];
+  violations: PolicyViolation[];
+};
+
 export type ParsedPlan = {
   resources: PlanResource[];
   summary: PlanSummary | null;
   outputs: PlanAttrChange[];
   driftDetected: boolean;
+  policy: PolicyReport | null;
   noDrift: boolean;
   /** Whether anything plan-like was found at all. */
   hasPlan: boolean;
@@ -96,9 +114,42 @@ function cleanValue(v: string): string {
     .trim();
 }
 
+/** Parse the `[policy]` block emitted by the worker's policy-as-code gate. */
+export function parsePolicyReport(log: string): PolicyReport | null {
+  if (!log || !/\[policy\]/.test(log)) return null;
+  const head = /\[policy\]\s*mode=(\S+)\s+deny=(\d+)\s+warn=(\d+)/.exec(log);
+  if (!head) return null;
+
+  const violations: PolicyViolation[] = [];
+  const re = /\[policy\]\s+(WARN|DENY|BLOCK)\s+(\S+)\s+(\S+)\s+[—-]\s+(.*)$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(log))) {
+    violations.push({
+      level: (m[1] ?? "WARN").toLowerCase() as PolicyViolation["level"],
+      rule: m[2] ?? "",
+      address: (m[3] ?? "").replace(/^\(plan\)$/, ""),
+      message: (m[4] ?? "").trim(),
+    });
+  }
+
+  const blockedMatch = /\[policy\]\s*FAILED\s*[—-]\s*run blocked by rule\(s\):\s*(.*)$/m.exec(log);
+  return {
+    mode: head[1] ?? "warn",
+    denies: Number(head[2] ?? 0),
+    warns: Number(head[3] ?? 0),
+    passed: /\[policy\]\s*PASS\b/.test(log),
+    blocked: Boolean(blockedMatch),
+    blockedBy: blockedMatch
+      ? (blockedMatch[1] ?? "").split(",").map((r) => r.trim()).filter(Boolean)
+      : [],
+    violations,
+  };
+}
+
 export function parseTofuPlan(log: string): ParsedPlan {
   const empty: ParsedPlan = {
-    resources: [], summary: null, outputs: [], driftDetected: false, noDrift: false, hasPlan: false,
+    resources: [], summary: null, outputs: [], driftDetected: false, noDrift: false,
+    policy: null, hasPlan: false,
   };
   if (!log) return empty;
 
@@ -176,6 +227,7 @@ export function parseTofuPlan(log: string): ParsedPlan {
     /Objects have changed outside of (OpenTofu|Terraform)/i.test(log) ||
     resources.some((r) => r.action === "drift");
   const noDrift = !driftDetected && /\[drift\]\s*no drift/i.test(log);
+  const policy = parsePolicyReport(log);
 
   return {
     resources,
@@ -183,7 +235,10 @@ export function parseTofuPlan(log: string): ParsedPlan {
     outputs,
     driftDetected,
     noDrift,
-    hasPlan: resources.length > 0 || summary !== null || outputs.length > 0 || driftDetected || noDrift,
+    policy,
+    hasPlan:
+      resources.length > 0 || summary !== null || outputs.length > 0 || driftDetected || noDrift ||
+      policy !== null,
   };
 }
 

--- a/console/src/routes/cloud/stacks/$stackId.tsx
+++ b/console/src/routes/cloud/stacks/$stackId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft, CheckCircle2, Download, Search, Rocket, Bomb, RefreshCcw, RefreshCw, Clock,
@@ -99,6 +100,14 @@ function StackDetail() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showInventory, setShowInventory] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!settingsOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, [settingsOpen]);
+
 
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [flowLog, setFlowLog] = useState("");
@@ -411,13 +420,13 @@ function StackDetail() {
         </div>
       )}
 
-      {settingsOpen && (
-      <div className="fixed inset-0 z-50 flex justify-end bg-black/50" onClick={() => setSettingsOpen(false)}>
+      {settingsOpen && createPortal(
+      <div className="fixed inset-0 z-[100] flex justify-end bg-black/50" onClick={() => setSettingsOpen(false)}>
       <div
-        className="h-full w-full max-w-2xl bg-[var(--color-card)] border-l border-[var(--color-border)] shadow-2xl overflow-y-auto animate-in slide-in-from-right duration-200"
+        className="flex h-screen w-full max-w-2xl flex-col bg-[var(--color-card)] border-l border-[var(--color-border)] shadow-2xl animate-in slide-in-from-right duration-200"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between p-4 border-b border-[var(--color-border)] sticky top-0 bg-[var(--color-card)] z-10">
+        <div className="flex items-center justify-between p-4 border-b border-[var(--color-border)] bg-[var(--color-card)] shrink-0">
           <div>
             <h3 className="text-base font-semibold flex items-center gap-2">
               <Settings className="h-4 w-4" /> Settings
@@ -428,7 +437,8 @@ function StackDetail() {
             <X className="h-4 w-4" />
           </button>
         </div>
-        <div className="p-4 pb-24 space-y-4">
+        <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain p-4 space-y-4">
+
       <Card>
 
         <CardHeader className="flex flex-row items-start justify-between gap-4">
@@ -504,7 +514,8 @@ function StackDetail() {
       <PolicyGateCard stackId={stackId} />
         </div>
       </div>
-      </div>
+      </div>,
+      document.body
       )}
 
 

--- a/console/src/routes/cloud/stacks/$stackId.tsx
+++ b/console/src/routes/cloud/stacks/$stackId.tsx
@@ -414,7 +414,7 @@ function StackDetail() {
       {settingsOpen && (
       <div className="fixed inset-0 z-50 flex justify-end bg-black/50" onClick={() => setSettingsOpen(false)}>
       <div
-        className="h-full w-full max-w-xl bg-[var(--color-card)] border-l border-[var(--color-border)] shadow-2xl overflow-y-auto animate-in slide-in-from-right duration-200"
+        className="h-full w-full max-w-2xl bg-[var(--color-card)] border-l border-[var(--color-border)] shadow-2xl overflow-y-auto animate-in slide-in-from-right duration-200"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between p-4 border-b border-[var(--color-border)] sticky top-0 bg-[var(--color-card)] z-10">
@@ -428,7 +428,7 @@ function StackDetail() {
             <X className="h-4 w-4" />
           </button>
         </div>
-        <div className="p-4 space-y-4">
+        <div className="p-4 pb-24 space-y-4">
       <Card>
 
         <CardHeader className="flex flex-row items-start justify-between gap-4">

--- a/server/services/cloud_policy.py
+++ b/server/services/cloud_policy.py
@@ -4,6 +4,7 @@ Policy-as-code gate for Cloud Provisioning stacks (opt-in per stack).
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -18,7 +19,32 @@ POLICY_RULE_TYPES = {
 }
 
 SEVERITIES = ("warn", "deny")
+CUSTOM_SEVERITIES = ("info", "warn", "deny")
+
+
 ENFORCEMENTS = ("inherit", "block", "report")
+
+# Custom (user-defined) rules -------------------------------------------------
+CUSTOM_OPERATORS = (
+    "matches",       # regex match against the attribute value
+    "not_matches",
+    "equals",
+    "not_equals",
+    "exists",
+    "not_exists",
+    "gt",
+    "lt",
+)
+CUSTOM_ACTIONS = ("create", "update", "delete", "read", "no-op")
+MAX_CUSTOM_RULES = 100
+
+_SLUG_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+
+
+def _slugify(value: str, fallback: str) -> str:
+    s = "".join(c if c in _SLUG_CHARS else "-" for c in str(value or "").strip().lower())
+    s = "-".join(p for p in s.split("-") if p)
+    return s[:64] or fallback
 
 
 def default_policy() -> Dict[str, Any]:
@@ -33,7 +59,10 @@ def default_policy() -> Dict[str, Any]:
             "deny_public_ingress": {"enabled": True, "severity": "deny", "enforcement": "inherit", "ports": [22, 3389]},
             "max_created": {"enabled": False, "severity": "warn", "enforcement": "inherit", "limit": 50},
         },
+        # User-defined rules (YAML/DSL in the UI, JSON on the wire).
+        "custom_rules": [],
     }
+
 
 
 def policy_enabled_from_meta(meta: Dict[str, Any]) -> bool:
@@ -50,7 +79,103 @@ def policy_config_from_meta(meta: Dict[str, Any]) -> Dict[str, Any]:
         for rid, rule in (stored.get("rules") or {}).items():
             if rid in cfg["rules"] and isinstance(rule, dict):
                 cfg["rules"][rid].update({k: v for k, v in rule.items() if k != "id"})
+        custom = stored.get("custom_rules")
+        if isinstance(custom, list):
+            cfg["custom_rules"] = sanitize_custom_rules(custom)
     return cfg
+
+
+def sanitize_custom_rules(items: Any) -> list:
+    """Validate user-defined rules. Anything malformed is dropped rather than
+    silently turned into a rule that matches everything."""
+    if not isinstance(items, list):
+        return []
+    out: list = []
+    seen_ids = set()
+    for idx, raw in enumerate(items[:MAX_CUSTOM_RULES]):
+        if not isinstance(raw, dict):
+            continue
+        name = str(raw.get("name") or raw.get("id") or "").strip()[:120]
+        rid = _slugify(raw.get("id") or name, f"rule-{idx + 1}")
+        base = rid
+        n = 2
+        while rid in seen_ids:
+            rid = f"{base}-{n}"
+            n += 1
+        seen_ids.add(rid)
+
+        op = str(raw.get("operator") or "matches").strip().lower()
+        if op not in CUSTOM_OPERATORS:
+            op = "matches"
+        sev = str(raw.get("severity") or "warn").strip().lower()
+        if sev not in CUSTOM_SEVERITIES:
+            sev = "warn"
+        enf = str(raw.get("enforcement") or "inherit").strip().lower()
+        if enf not in ENFORCEMENTS:
+            enf = "inherit"
+
+        def _regex_list(value: Any, limit: int = 50) -> list:
+            if isinstance(value, str):
+                value = [value]
+            if not isinstance(value, list):
+                return []
+            clean = []
+            for v in value[:limit]:
+                s = str(v).strip()
+                if not s:
+                    continue
+                try:
+                    re.compile(s)
+                except re.error:
+                    continue
+                clean.append(s[:400])
+            return clean
+
+        actions = raw.get("actions")
+        if isinstance(actions, str):
+            actions = [actions]
+        actions = [
+            str(a).strip().lower()
+            for a in (actions or [])
+            if str(a).strip().lower() in CUSTOM_ACTIONS
+        ]
+
+        value = raw.get("value")
+        if value is None:
+            value = raw.get("pattern")
+        if isinstance(value, (dict, list)):
+            value = ""
+        value = "" if value is None else str(value)[:400]
+        if op in ("matches", "not_matches") and value:
+            try:
+                re.compile(value)
+            except re.error:
+                continue  # invalid regex -> drop the rule
+
+        attribute = str(raw.get("attribute") or "").strip()[:200]
+        if op not in ("exists", "not_exists") and not attribute and not value:
+            # Nothing to compare against — a rule like this would match all.
+            if not raw.get("resource_types"):
+                continue
+
+        out.append(
+            {
+                "id": rid,
+                "name": name or rid,
+                "description": str(raw.get("description") or "").strip()[:400],
+                "enabled": bool(raw.get("enabled", True)),
+                "severity": sev,
+                "enforcement": enf,
+                "resource_types": _regex_list(raw.get("resource_types")),
+                "addresses": _regex_list(raw.get("addresses")),
+                "actions": actions,
+                "attribute": attribute,
+                "operator": op,
+                "value": value,
+                "message": str(raw.get("message") or "").strip()[:400],
+            }
+        )
+    return out
 
 
 def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
@@ -58,6 +183,7 @@ def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
     mode = (body.get("mode") or "").strip().lower()
     if mode in ("warn", "enforce"):
         cfg["mode"] = mode
+    cfg["custom_rules"] = sanitize_custom_rules(body.get("custom_rules"))
     rules = body.get("rules") or {}
     if not isinstance(rules, dict):
         return cfg
@@ -105,6 +231,7 @@ def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
     return cfg
 
 
+
 def latest_policy_result(ex_dir: Path, name: str) -> Optional[Dict[str, Any]]:
     """Most recent policy verdict recorded by a worker for this stack."""
     if not ex_dir or not ex_dir.exists():
@@ -129,6 +256,8 @@ def latest_policy_result(ex_dir: Path, name: str) -> Optional[Dict[str, Any]]:
             "verdict": pol.get("verdict"),
             "denies": pol.get("denies"),
             "warns": pol.get("warns"),
+            "infos": pol.get("infos"),
+
             "blocked": bool(pol.get("blocked")),
             "blocked_by": pol.get("blocked_by") or [],
             "violations": pol.get("violations") or [],

--- a/server/services/cloud_policy.py
+++ b/server/services/cloud_policy.py
@@ -18,6 +18,7 @@ POLICY_RULE_TYPES = {
 }
 
 SEVERITIES = ("warn", "deny")
+ENFORCEMENTS = ("inherit", "block", "report")
 
 
 def default_policy() -> Dict[str, Any]:
@@ -26,11 +27,11 @@ def default_policy() -> Dict[str, Any]:
     return {
         "mode": "warn",  # warn | enforce
         "rules": {
-            "deny_destroy": {"enabled": False, "severity": "deny", "max_destroy": 0},
-            "denied_resource_types": {"enabled": False, "severity": "deny", "types": []},
-            "require_tags": {"enabled": False, "severity": "warn", "keys": ["environment", "owner"]},
-            "deny_public_ingress": {"enabled": True, "severity": "deny", "ports": [22, 3389]},
-            "max_created": {"enabled": False, "severity": "warn", "limit": 50},
+            "deny_destroy": {"enabled": False, "severity": "deny", "enforcement": "inherit", "max_destroy": 0},
+            "denied_resource_types": {"enabled": False, "severity": "deny", "enforcement": "inherit", "types": []},
+            "require_tags": {"enabled": False, "severity": "warn", "enforcement": "inherit", "keys": ["environment", "owner"]},
+            "deny_public_ingress": {"enabled": True, "severity": "deny", "enforcement": "inherit", "ports": [22, 3389]},
+            "max_created": {"enabled": False, "severity": "warn", "enforcement": "inherit", "limit": 50},
         },
     }
 
@@ -68,6 +69,9 @@ def sanitize_policy(body: Dict[str, Any]) -> Dict[str, Any]:
         sev = (incoming.get("severity") or "").strip().lower()
         if sev in SEVERITIES:
             target["severity"] = sev
+        enf = (incoming.get("enforcement") or "").strip().lower()
+        if enf in ENFORCEMENTS:
+            target["enforcement"] = enf
         if rid == "deny_destroy":
             try:
                 target["max_destroy"] = max(0, int(incoming.get("max_destroy", 0)))
@@ -125,6 +129,8 @@ def latest_policy_result(ex_dir: Path, name: str) -> Optional[Dict[str, Any]]:
             "verdict": pol.get("verdict"),
             "denies": pol.get("denies"),
             "warns": pol.get("warns"),
+            "blocked": bool(pol.get("blocked")),
+            "blocked_by": pol.get("blocked_by") or [],
             "violations": pol.get("violations") or [],
         }
     return None

--- a/worker/internal/execute/policy.go
+++ b/worker/internal/execute/policy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -25,14 +26,31 @@ type policyRule struct {
 	Ports       []int    `json:"ports"`
 	Limit       int      `json:"limit"`
 }
+type customRule struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description"`
+	Enabled       bool     `json:"enabled"`
+	Severity      string   `json:"severity"`    // info | warn | deny
+	Enforcement   string   `json:"enforcement"` // inherit | block | report
+	ResourceTypes []string `json:"resource_types"`
+	Addresses     []string `json:"addresses"`
+	Actions       []string `json:"actions"`
+	Attribute     string   `json:"attribute"`
+	Operator      string   `json:"operator"`
+	Value         string   `json:"value"`
+	Message       string   `json:"message"`
+}
 
 type policyConfig struct {
-	Mode  string                `json:"mode"` // warn | enforce
-	Rules map[string]policyRule `json:"rules"`
+	Mode        string                `json:"mode"` // warn | enforce
+	Rules       map[string]policyRule `json:"rules"`
+	CustomRules []customRule          `json:"custom_rules"`
 }
 
 type Violation struct {
 	Rule     string `json:"rule"`
+	Name     string `json:"name,omitempty"`
 	Severity string `json:"severity"`
 	Blocking bool   `json:"blocking"`
 	Address  string `json:"address,omitempty"`
@@ -45,11 +63,13 @@ type PolicyResult struct {
 	Mode    string `json:"mode"`
 	Denies  int    `json:"denies"`
 	Warns   int    `json:"warns"`
+	Infos   int    `json:"infos"`
 	// Blocked is true when at least one violation is blocking.
 	Blocked    bool        `json:"blocked"`
 	BlockedBy  []string    `json:"blocked_by,omitempty"`
 	Violations []Violation `json:"violations"`
 }
+
 
 func parsePolicyConfig(raw any) *policyConfig {
 	if raw == nil {
@@ -66,12 +86,14 @@ func parsePolicyConfig(raw any) *policyConfig {
 	if cfg.Mode != "enforce" {
 		cfg.Mode = "warn"
 	}
-	if len(cfg.Rules) == 0 {
-		return nil
-	}
 	// Nothing enabled → treat as absent so we skip the whole gate.
 	for _, r := range cfg.Rules {
 		if r.Enabled {
+			return &cfg
+		}
+	}
+	for _, c := range cfg.CustomRules {
+		if c.Enabled {
 			return &cfg
 		}
 	}
@@ -131,6 +153,7 @@ func enforcementOf(r policyRule) string {
 	}
 }
 
+
 func ruleBlocks(r policyRule, mode string) bool {
 	switch enforcementOf(r) {
 	case "block":
@@ -141,6 +164,259 @@ func ruleBlocks(r policyRule, mode string) bool {
 		return sevOf(r) == "deny" && mode == "enforce"
 	}
 }
+
+
+func customSevOf(c customRule) string {
+	switch strings.ToLower(strings.TrimSpace(c.Severity)) {
+	case "deny":
+		return "deny"
+	case "info":
+		return "info"
+	default:
+		return "warn"
+	}
+}
+
+func customRuleBlocks(c customRule, mode string) bool {
+	switch strings.ToLower(strings.TrimSpace(c.Enforcement)) {
+	case "block":
+		return true
+	case "report":
+		return false
+	default:
+		return customSevOf(c) == "deny" && mode == "enforce"
+	}
+}
+
+// anyRegexMatch reports whether s matches any of the patterns. An empty
+// pattern list means "no constraint" and matches everything.
+func anyRegexMatch(patterns []string, s string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			continue
+		}
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func lookupAttribute(root any, path string) []any {
+	if strings.TrimSpace(path) == "" {
+		if root == nil {
+			return nil
+		}
+		return []any{root}
+	}
+	current := []any{root}
+	for _, seg := range strings.Split(path, ".") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		var next []any
+		for _, node := range current {
+			switch t := node.(type) {
+			case map[string]any:
+				if seg == "*" {
+					for _, v := range t {
+						next = append(next, v)
+					}
+				} else if v, ok := t[seg]; ok {
+					next = append(next, v)
+				}
+			case []any:
+				if seg == "*" {
+					next = append(next, t...)
+				} else if idx, ok := asInt(seg); ok && idx >= 0 && idx < len(t) {
+					next = append(next, t[idx])
+				} else {
+					// Allow "ingress.cidr_blocks" against a list of objects.
+					for _, e := range t {
+						if m, ok := e.(map[string]any); ok {
+							if v, ok := m[seg]; ok {
+								next = append(next, v)
+							}
+						}
+					}
+				}
+			}
+		}
+		if len(next) == 0 {
+			return nil
+		}
+		current = next
+	}
+	return current
+}
+
+func flattenValues(vals []any) []any {
+	var out []any
+	for _, v := range vals {
+		if list, ok := v.([]any); ok {
+			out = append(out, flattenValues(list)...)
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func valueToString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%v", t)
+	case bool:
+		return fmt.Sprintf("%t", t)
+	case map[string]any, []any:
+		if b, err := json.Marshal(t); err == nil {
+			return string(b)
+		}
+	}
+	return fmt.Sprint(v)
+}
+
+func asFloat(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case int:
+		return float64(t), true
+	case bool:
+		if t {
+			return 1, true
+		}
+		return 0, true
+	case string:
+		var f float64
+		if _, err := fmt.Sscanf(strings.TrimSpace(t), "%g", &f); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+
+func evalCustomRule(c customRule, rc planResourceChange) []string {
+	if !anyRegexMatch(c.ResourceTypes, rc.Type) {
+		return nil
+	}
+	if !anyRegexMatch(c.Addresses, rc.Address) {
+		return nil
+	}
+	actions := c.Actions
+	if len(actions) == 0 {
+		actions = []string{"create", "update"}
+	}
+	matchedAction := false
+	for _, a := range actions {
+		if hasAction(rc.Change.Actions, strings.ToLower(strings.TrimSpace(a))) {
+			matchedAction = true
+			break
+		}
+	}
+	if !matchedAction {
+		return nil
+	}
+
+	op := strings.ToLower(strings.TrimSpace(c.Operator))
+	if op == "" {
+		op = "matches"
+	}
+	found := flattenValues(lookupAttribute(map[string]any(rc.Change.After), c.Attribute))
+
+	msg := c.Message
+	fallback := func(detail string) string {
+		if msg != "" {
+			return msg
+		}
+		return detail
+	}
+	attrLabel := c.Attribute
+	if attrLabel == "" {
+		attrLabel = "resource"
+	}
+
+	switch op {
+	case "exists":
+		if len(found) == 0 {
+			return []string{fallback(fmt.Sprintf("attribute %q is required but not set", attrLabel))}
+		}
+		return nil
+	case "not_exists":
+		if len(found) > 0 {
+			return []string{fallback(fmt.Sprintf("attribute %q must not be set", attrLabel))}
+		}
+		return nil
+	}
+
+	if len(found) == 0 {
+		// Nothing to compare — "not_matches"/"not_equals" are satisfied by absence.
+		return nil
+	}
+
+	var re *regexp.Regexp
+	if op == "matches" || op == "not_matches" {
+		compiled, err := regexp.Compile(c.Value)
+		if err != nil {
+			return []string{fmt.Sprintf("rule has an invalid regex (%s): %v", c.Value, err)}
+		}
+		re = compiled
+	}
+
+	var hits []string
+	for _, v := range found {
+		s := valueToString(v)
+		switch op {
+		case "matches":
+			if re.MatchString(s) {
+				hits = append(hits, fallback(fmt.Sprintf("%s = %q matches /%s/", attrLabel, s, c.Value)))
+			}
+		case "not_matches":
+			if !re.MatchString(s) {
+				hits = append(hits, fallback(fmt.Sprintf("%s = %q does not match /%s/", attrLabel, s, c.Value)))
+			}
+		case "equals":
+			if s == c.Value {
+				hits = append(hits, fallback(fmt.Sprintf("%s equals %q", attrLabel, c.Value)))
+			}
+		case "not_equals":
+			if s != c.Value {
+				hits = append(hits, fallback(fmt.Sprintf("%s = %q, expected %q", attrLabel, s, c.Value)))
+			}
+		case "gt", "lt":
+			want, ok1 := asFloat(c.Value)
+			got, ok2 := asFloat(v)
+			if !ok1 || !ok2 {
+				continue
+			}
+			if (op == "gt" && got > want) || (op == "lt" && got < want) {
+				sym := ">"
+				if op == "lt" {
+					sym = "<"
+				}
+				hits = append(hits, fallback(fmt.Sprintf("%s = %s is %s %s", attrLabel, s, sym, c.Value)))
+			}
+		}
+		if len(hits) > 0 {
+			break // one violation per resource is enough
+		}
+	}
+	return hits
+}
+
 
 // evaluatePolicy applies the enabled rules to the plan JSON.
 func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
@@ -244,11 +520,36 @@ func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 			fmt.Sprintf("plan creates %d resources, above the limit of %d", created, r.Limit))
 	}
 
+	// --- custom (user-defined) rules ----------------------------------------
+	for _, c := range cfg.CustomRules {
+		if !c.Enabled {
+			continue
+		}
+		ruleKey := "custom:" + c.ID
+		sev := customSevOf(c)
+		blocks := customRuleBlocks(c, cfg.Mode)
+		name := c.Name
+		if name == "" {
+			name = c.ID
+		}
+		for _, rc := range plan.ResourceChanges {
+			for _, msg := range evalCustomRule(c, rc) {
+				res.Violations = append(res.Violations, Violation{
+					Rule: ruleKey, Name: name, Severity: sev, Blocking: blocks,
+					Address: rc.Address, Type: rc.Type, Message: msg,
+				})
+			}
+		}
+	}
+
 	seenBlocked := map[string]bool{}
 	for _, v := range res.Violations {
-		if v.Severity == "deny" {
+		switch v.Severity {
+		case "deny":
 			res.Denies++
-		} else {
+		case "info":
+			res.Infos++
+		default:
 			res.Warns++
 		}
 		if v.Blocking && !seenBlocked[v.Rule] {
@@ -256,6 +557,7 @@ func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 			res.BlockedBy = append(res.BlockedBy, v.Rule)
 		}
 	}
+
 	sort.Strings(res.BlockedBy)
 	res.Blocked = len(res.BlockedBy) > 0
 	switch {
@@ -267,6 +569,8 @@ func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 	return res, nil
 }
 
+// resourceTags normalises the many tag shapes providers use. Returns nil when
+// the resource has no recognisable tag attribute.
 func resourceTags(after map[string]any) map[string]string {
 	if after == nil {
 		return nil
@@ -398,7 +702,8 @@ func asInt(v any) (int, bool) {
 	return 0, false
 }
 
-
+// ruleCoversPort reports whether a rule's port range includes p. A rule with no
+// recognisable port info is treated as "all ports" (i.e. it covers p).
 func ruleCoversPort(rule map[string]any, p int) bool {
 	if proto, ok := rule["protocol"].(string); ok {
 		lp := strings.ToLower(strings.TrimSpace(proto))
@@ -431,6 +736,7 @@ func ruleCoversPort(rule map[string]any, p int) bool {
 			}
 		}
 	}
+	// from_port / to_port pairs (AWS style).
 	from, ok1 := asInt(rule["from_port"])
 	to, ok2 := asInt(rule["to_port"])
 	if ok1 && ok2 {
@@ -439,6 +745,7 @@ func ruleCoversPort(rule map[string]any, p int) bool {
 		}
 		return p >= from && p <= to
 	}
+	// No port information at all → assume the rule is wide open.
 	_, hasAnyPortKey := rule["from_port"]
 	return !hasAnyPortKey
 }
@@ -450,15 +757,18 @@ func ruleCoversPort(rule map[string]any, p int) bool {
 func formatPolicyReport(res *PolicyResult) string {
 	var b strings.Builder
 	b.WriteString("\n[policy] ── Policy-as-code gate ──────────────────────────────\n")
-	b.WriteString(fmt.Sprintf("[policy] mode=%s  deny=%d  warn=%d\n", res.Mode, res.Denies, res.Warns))
+	b.WriteString(fmt.Sprintf("[policy] mode=%s  deny=%d  warn=%d  info=%d\n", res.Mode, res.Denies, res.Warns, res.Infos))
 	if len(res.Violations) == 0 {
 		b.WriteString("[policy] PASS — no violations found.\n\n")
 		return b.String()
 	}
 	for _, v := range res.Violations {
 		label := "WARN"
-		if v.Severity == "deny" {
+		switch v.Severity {
+		case "deny":
 			label = "DENY"
+		case "info":
+			label = "INFO"
 		}
 		if v.Blocking {
 			label = "BLOCK"
@@ -467,7 +777,11 @@ func formatPolicyReport(res *PolicyResult) string {
 		if addr == "" {
 			addr = "(plan)"
 		}
-		b.WriteString(fmt.Sprintf("[policy] %s  %-22s %s — %s\n", label, v.Rule, addr, v.Message))
+		ruleLabel := v.Rule
+		if v.Name != "" {
+			ruleLabel = v.Name
+		}
+		b.WriteString(fmt.Sprintf("[policy] %s  %-22s %s — %s\n", label, ruleLabel, addr, v.Message))
 	}
 	switch {
 	case res.Blocked:

--- a/worker/internal/execute/policy.go
+++ b/worker/internal/execute/policy.go
@@ -11,14 +11,19 @@ import (
 	"time"
 )
 
+// ---------------------------------------------------------------------------
+// Config (mirrors backend _default_policy)
+// ---------------------------------------------------------------------------
+
 type policyRule struct {
-	Enabled    bool     `json:"enabled"`
-	Severity   string   `json:"severity"`
-	MaxDestroy int      `json:"max_destroy"`
-	Types      []string `json:"types"`
-	Keys       []string `json:"keys"`
-	Ports      []int    `json:"ports"`
-	Limit      int      `json:"limit"`
+	Enabled  bool   `json:"enabled"`
+	Severity string `json:"severity"`
+	Enforcement string   `json:"enforcement"`
+	MaxDestroy  int      `json:"max_destroy"`
+	Types       []string `json:"types"`
+	Keys        []string `json:"keys"`
+	Ports       []int    `json:"ports"`
+	Limit       int      `json:"limit"`
 }
 
 type policyConfig struct {
@@ -29,16 +34,20 @@ type policyConfig struct {
 type Violation struct {
 	Rule     string `json:"rule"`
 	Severity string `json:"severity"`
+	Blocking bool   `json:"blocking"`
 	Address  string `json:"address,omitempty"`
 	Type     string `json:"type,omitempty"`
 	Message  string `json:"message"`
 }
 
 type PolicyResult struct {
-	Verdict    string      `json:"verdict"` // pass | warn | fail
-	Mode       string      `json:"mode"`
-	Denies     int         `json:"denies"`
-	Warns      int         `json:"warns"`
+	Verdict string `json:"verdict"` // pass | warn | fail
+	Mode    string `json:"mode"`
+	Denies  int    `json:"denies"`
+	Warns   int    `json:"warns"`
+	// Blocked is true when at least one violation is blocking.
+	Blocked    bool        `json:"blocked"`
+	BlockedBy  []string    `json:"blocked_by,omitempty"`
 	Violations []Violation `json:"violations"`
 }
 
@@ -60,6 +69,7 @@ func parsePolicyConfig(raw any) *policyConfig {
 	if len(cfg.Rules) == 0 {
 		return nil
 	}
+	// Nothing enabled → treat as absent so we skip the whole gate.
 	for _, r := range cfg.Rules {
 		if r.Enabled {
 			return &cfg
@@ -83,6 +93,7 @@ type planJSON struct {
 	ResourceChanges []planResourceChange `json:"resource_changes"`
 }
 
+// showPlanJSON runs `tofu show -json <planFile>` in stackDir.
 func showPlanJSON(stackDir, planFile string, env []string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
@@ -108,6 +119,29 @@ func sevOf(r policyRule) string {
 	return "warn"
 }
 
+// enforcementOf normalises the per-rule enforcement override.
+func enforcementOf(r policyRule) string {
+	switch strings.ToLower(strings.TrimSpace(r.Enforcement)) {
+	case "block":
+		return "block"
+	case "report":
+		return "report"
+	default:
+		return "inherit"
+	}
+}
+
+func ruleBlocks(r policyRule, mode string) bool {
+	switch enforcementOf(r) {
+	case "block":
+		return true
+	case "report":
+		return false
+	default:
+		return sevOf(r) == "deny" && mode == "enforce"
+	}
+}
+
 // evaluatePolicy applies the enabled rules to the plan JSON.
 func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 	var plan planJSON
@@ -116,9 +150,13 @@ func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 	}
 
 	res := &PolicyResult{Verdict: "pass", Mode: cfg.Mode, Violations: []Violation{}}
+	blocking := map[string]bool{}
+	for id, r := range cfg.Rules {
+		blocking[id] = r.Enabled && ruleBlocks(r, cfg.Mode)
+	}
 	add := func(rule, sev, addr, rtype, msg string) {
 		res.Violations = append(res.Violations, Violation{
-			Rule: rule, Severity: sev, Address: addr, Type: rtype, Message: msg,
+			Rule: rule, Severity: sev, Blocking: blocking[rule], Address: addr, Type: rtype, Message: msg,
 		})
 	}
 
@@ -206,15 +244,22 @@ func evaluatePolicy(raw []byte, cfg *policyConfig) (*PolicyResult, error) {
 			fmt.Sprintf("plan creates %d resources, above the limit of %d", created, r.Limit))
 	}
 
+	seenBlocked := map[string]bool{}
 	for _, v := range res.Violations {
 		if v.Severity == "deny" {
 			res.Denies++
 		} else {
 			res.Warns++
 		}
+		if v.Blocking && !seenBlocked[v.Rule] {
+			seenBlocked[v.Rule] = true
+			res.BlockedBy = append(res.BlockedBy, v.Rule)
+		}
 	}
+	sort.Strings(res.BlockedBy)
+	res.Blocked = len(res.BlockedBy) > 0
 	switch {
-	case res.Denies > 0:
+	case res.Blocked || res.Denies > 0:
 		res.Verdict = "fail"
 	case res.Warns > 0:
 		res.Verdict = "warn"
@@ -257,6 +302,8 @@ func resourceTags(after map[string]any) map[string]string {
 
 var openCIDRs = map[string]bool{"0.0.0.0/0": true, "::/0": true, "0.0.0.0/0,::/0": true}
 
+// publicIngressHits scans a resource's planned attributes for firewall/security
+// group ingress rules that expose one of `ports` to the open internet.
 func publicIngressHits(after map[string]any, ports []int) []string {
 	if after == nil {
 		return nil
@@ -351,6 +398,7 @@ func asInt(v any) (int, bool) {
 	return 0, false
 }
 
+
 func ruleCoversPort(rule map[string]any, p int) bool {
 	if proto, ok := rule["protocol"].(string); ok {
 		lp := strings.ToLower(strings.TrimSpace(proto))
@@ -391,7 +439,6 @@ func ruleCoversPort(rule map[string]any, p int) bool {
 		}
 		return p >= from && p <= to
 	}
-
 	_, hasAnyPortKey := rule["from_port"]
 	return !hasAnyPortKey
 }
@@ -413,6 +460,9 @@ func formatPolicyReport(res *PolicyResult) string {
 		if v.Severity == "deny" {
 			label = "DENY"
 		}
+		if v.Blocking {
+			label = "BLOCK"
+		}
 		addr := v.Address
 		if addr == "" {
 			addr = "(plan)"
@@ -420,10 +470,10 @@ func formatPolicyReport(res *PolicyResult) string {
 		b.WriteString(fmt.Sprintf("[policy] %s  %-22s %s — %s\n", label, v.Rule, addr, v.Message))
 	}
 	switch {
-	case res.Denies > 0 && res.Mode == "enforce":
-		b.WriteString("[policy] FAILED — the run is blocked because the gate is in enforce mode.\n\n")
+	case res.Blocked:
+		b.WriteString("[policy] FAILED — run blocked by rule(s): " + strings.Join(res.BlockedBy, ", ") + "\n\n")
 	case res.Denies > 0:
-		b.WriteString("[policy] Violations found, but the gate is in warn mode — continuing.\n\n")
+		b.WriteString("[policy] Violations found, but no rule is set to block this run — continuing.\n\n")
 	default:
 		b.WriteString("[policy] Warnings only — continuing.\n\n")
 	}

--- a/worker/internal/execute/tofu.go
+++ b/worker/internal/execute/tofu.go
@@ -212,8 +212,6 @@ func syncIaCIntoStack(stackDir, provider string, log func(string)) {
 	log(fmt.Sprintf("[sync] refreshed %s modules/ and %d template .tf files in %s\n", provider, copied, stackDir))
 }
 
-
-
 // otherProviderPresent walks stacksRoot/envs/* and returns true if any stack
 // dir other than the current one has an .opensible-provider marker pointing at
 // a different provider. Used to decide whether it's safe to touch the shared
@@ -255,13 +253,12 @@ func executeTofuRun(executionID string, execData map[string]any, projectID strin
 	extraEnv, _ := runParams["env"].(map[string]any)
 	provider, _ := runParams["provider"].(string)
 
-
 	sendLog := func(text string) { client.SendLog(executionID, text, 0) }
 	startTime := time.Now()
 	finalStatus := "FAILED"
 	var returnCode *int
 	var credsPath string
-
+	// Policy gate: nil unless the backend shipped an opted-in policy payload.
 	policyCfg := parsePolicyConfig(runParams["policy"])
 	var policyRes *PolicyResult
 
@@ -276,7 +273,6 @@ func executeTofuRun(executionID string, execData map[string]any, projectID strin
 		}
 		client.FinishExecution(executionID, finalStatus, float64(time.Now().Unix()), duration, returnCode, "", result)
 	}()
-
 
 	client.Heartbeat(executionID)
 
@@ -400,14 +396,13 @@ func executeTofuRun(executionID string, execData map[string]any, projectID strin
 		}
 		policyRes = res
 		sendLog(formatPolicyReport(res))
-		if res.Denies > 0 && policyCfg.Mode == "enforce" {
+		if res.Blocked {
 			finalStatus = "FAILED"
 			rc := 3
 			returnCode = &rc
 			return
 		}
 	}
-
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -531,13 +526,14 @@ loop:
 			sendLog("\n[drift] DRIFT DETECTED — the live infrastructure differs from the recorded state (see plan above).\n")
 		}
 	}
-
+	// Policy evaluation for a plain `plan` run: reuse the tfplan that was just
+	// written, so the only extra work is one local `tofu show -json`.
 	if policyCfg != nil && strings.EqualFold(action, "plan") && finalStatus == "SUCCESS" && !killed {
 		if raw, serr := showPlanJSON(stackDir, "tfplan", env); serr == nil {
 			if res, eerr := evaluatePolicy(raw, policyCfg); eerr == nil {
 				policyRes = res
 				sendLog(formatPolicyReport(res))
-				if res.Denies > 0 && policyCfg.Mode == "enforce" {
+				if res.Blocked {
 					finalStatus = "FAILED"
 					rc := 3
 					returnCode = &rc
@@ -552,7 +548,6 @@ loop:
 	if killed {
 		finalStatus = "CANCELED"
 	}
-
 
 	// Snapshot tfstate on success.
 	if finalStatus == "SUCCESS" && (action == "apply" || action == "destroy" || action == "refresh" || action == "plan") {


### PR DESCRIPTION
- Implemented Policy-as-Code custom rules with regex support across backend, worker, and frontend.
- Added Custom (user-defined) policy rules editors
- fix render settings panel in a portal at full viewport height
- enhance: add policy-as-code gate to plan diff UX
- Improve the existing Policy-as-Code Gate to support per-rule enforcement
