### PR TITLE
fix(kubeadm-blueprint): validate renderer configuration

### DIFF
--- a/IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/README.md
+++ b/IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/README.md
@@ -1,15 +1,42 @@
 # Kubernetes HA (kubeadm)
 
-Bootstraps a production-ready Kubernetes cluster with `kubeadm`. Supports
-single or multi control-plane, Calico/Flannel/Cilium CNI, and optional
-`metrics-server`, Longhorn, NFS, or local-path storage.
+Bootstraps a single or multi-control-plane Kubernetes cluster with `kubeadm`
+and containerd. The OpenSible `k8s-cluster` renderer supports Calico, Flannel,
+or manual CNI installation, plus optional metrics-server and storage add-ons.
 
-## Usage
+## OpenSible renderer
+
+Configure and render this blueprint from the OpenSible console. The renderer
+validates configuration before it generates or saves a playbook:
+
+- `kubernetes_version` must be a full patch version such as `1.30.4` (an
+  optional leading `v` is accepted).
+- Pod and service networks must be strict, non-overlapping IPv4 CIDRs.
+- Flannel currently requires `pod_cidr: 10.244.0.0/16`, matching its upstream
+  manifest. Calico accepts another valid IPv4 pod CIDR; `none` leaves CNI
+  installation to the operator.
+- `kube_proxy_mode: none` is only accepted with `cni_plugin: none`.
+- Supported storage values are `none`, `longhorn`, `local-path`,
+  `openebs-hostpath`, and `nfs-subdir`. NFS requires a server and absolute
+  export path.
+- At least one control-plane node is required. Node addresses and generated
+  Kubernetes node names must be unique, and SSH ports must be valid.
+- An optional control-plane endpoint must use `host:port` syntax.
+
+The current contract is IPv4 single-stack. Cilium, dual-stack/IPv6, and other
+container runtimes are not implemented by this renderer.
+
+## Static example playbook
+
+`playbook.yml` is a fixed example generated from the renderer defaults. Its
+cluster hosts, version, networks, CNI, and add-ons are already embedded; it is
+not a variable-driven entrypoint and does not consume `vars.example.yml`.
+
+To use custom values, render a new playbook in OpenSible. The static example
+can be run as-is after adapting its embedded hosts:
 
 ```bash
-ansible-playbook -i inventory.yml \
-  -e @vars.example.yml \
-  IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/playbook.yml
+ansible-playbook -i inventory.yml IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/playbook.yml
 ```
 
 ## Highlights
@@ -18,8 +45,9 @@ ansible-playbook -i inventory.yml \
   and self-heal via `kubeadm reset` on transient errors.
 - **Clean reinstall**: `reset_existing_cluster: true` purges kubeadm/k3s state,
   frees port 6443, and flushes IPVS/iptables/CNI leftovers.
-- **Storage**: pick `local-path`, `longhorn`, `nfs`, or `none`. The chosen
-  class is marked default when `storage_default_class: true`.
+- **Storage**: pick `local-path`, `longhorn`, `openebs-hostpath`,
+  `nfs-subdir`, or `none`. The chosen class is marked default when
+  `storage_default_class: true`.
 - **Kubeconfig**: fetched to the runner as `~/.kube/<cluster_name>.yaml`.
 
 ## Notes

--- a/IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/blueprint.yaml
+++ b/IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/blueprint.yaml
@@ -2,7 +2,7 @@ id: k8s-kubeadm-ha
 name: Kubernetes HA (kubeadm)
 group: kubernetes
 category: Kubernetes
-description: Multi control-plane kubeadm cluster with Calico CNI and metrics-server.
+description: Single or multi-control-plane kubeadm cluster with validated IPv4 networking and optional add-ons.
 logo: https://cdn.simpleicons.org/kubernetes/326CE5
 tags: [kubeadm, HA, calico]
 author: opensible
@@ -14,10 +14,13 @@ entrypoint: playbook.yml
 variables:
   cluster_name: opensible
   ha_mode: false
-  kubernetes_version: "1.30"
+  control_plane_endpoint: ""
+  kubernetes_version: "1.30.4"
   pod_cidr: 10.244.0.0/16
   service_cidr: 10.96.0.0/12
   cni_plugin: calico
   container_runtime: containerd
+  kube_proxy_mode: iptables
   install_metrics_server: true
-  storage_provisioner: local-path
+  storage_provisioner: none
+  reset_existing_cluster: false

--- a/IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/vars.example.yml
+++ b/IaC/blueprints/kubernetes/kubernetes-ha-kubeadm/vars.example.yml
@@ -3,19 +3,26 @@ cluster_name: opensible
 ha_mode: false
 # Set to your load-balancer VIP or DNS when ha_mode is true.
 control_plane_endpoint: ""
-kubernetes_version: "1.30"
+# A full patch version is required; an optional leading "v" is accepted.
+kubernetes_version: "1.30.4"
 
+# IPv4 single-stack only. Pod and service CIDRs must not overlap.
 pod_cidr: 10.244.0.0/16
 service_cidr: 10.96.0.0/12
-cni_plugin: calico          # calico | flannel | cilium
+# Flannel requires pod_cidr 10.244.0.0/16; "none" means install a CNI manually.
+cni_plugin: calico          # calico | flannel | none
 container_runtime: containerd
+# "none" is only valid with cni_plugin: none.
 kube_proxy_mode: iptables
 
 install_metrics_server: true
-storage_provisioner: local-path   # local-path | longhorn | nfs | none
+storage_provisioner: none   # none | longhorn | local-path | openebs-hostpath | nfs-subdir
 storage_default_class: true
+# Required when storage_provisioner is nfs-subdir.
+nfs_server: ""
+nfs_path: /srv/nfs/k8s
 
-reset_existing_cluster: true
+reset_existing_cluster: false
 allow_scheduling_on_control_plane: false
 fetch_kubeconfig: true
 

--- a/console/src/components/infrastructure/TemplateDialog.tsx
+++ b/console/src/components/infrastructure/TemplateDialog.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { YamlEditor } from "@/components/ui/yaml-editor";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { TemplateInstanceHistoryDialog } from "./TemplateInstanceHistoryDialog";
 import { WorkerSelect } from "./WorkerSelect";
 
@@ -28,6 +28,50 @@ type TemplateDetail = {
 
 type GroupsResp = { groups?: Record<string, { hosts?: string[] }> };
 type NodeRow = { name: string; ip: string; ssh_user: string; ssh_port: string };
+type TemplateFieldErrors = Record<string, string[]>;
+
+function templateFieldErrors(error: unknown): TemplateFieldErrors {
+  if (!(error instanceof ApiError) || !error.body || typeof error.body !== "object" || Array.isArray(error.body)) {
+    return {};
+  }
+
+  const raw = (error.body as Record<string, unknown>).field_errors;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+
+  return Object.fromEntries(
+    Object.entries(raw).flatMap(([field, messages]) => {
+      const normalized = Array.isArray(messages)
+        ? messages.filter((message): message is string => typeof message === "string" && message.trim().length > 0)
+        : typeof messages === "string" && messages.trim() ? [messages] : [];
+      return normalized.length ? [[field, normalized]] : [];
+    }),
+  );
+}
+
+function TemplateValidationMessages({
+  name,
+  fieldErrors,
+}: {
+  name: string;
+  fieldErrors: TemplateFieldErrors;
+}) {
+  const messages = Object.entries(fieldErrors).flatMap(([field, errors]) => {
+    if (field === name) return errors;
+    if (field.startsWith(`${name}.`) || field.startsWith(`${name}[`)) {
+      return errors.map((error) => `${field}: ${error}`);
+    }
+    return [];
+  });
+  if (!messages.length) return null;
+
+  return (
+    <div role="alert" className="mt-1 space-y-0.5 text-[11px] text-[var(--color-destructive)]">
+      {messages.map((message, index) => (
+        <div key={`${message}-${index}`}>{message}</div>
+      ))}
+    </div>
+  );
+}
 
 export function TemplateDialog({
   templateId,
@@ -58,6 +102,7 @@ export function TemplateDialog({
   const [filename, setFilename] = useState<string>(initialFilename || "");
   const [busy, setBusy] = useState<null | "render" | "save" | "run">(null);
   const [workerId, setWorkerId] = useState<string>("");
+  const [fieldErrors, setFieldErrors] = useState<TemplateFieldErrors>({});
 
   const [runId, setRunId] = useState<string | null>(null);
   const [playbookFullscreen, setPlaybookFullscreen] = useState(false);
@@ -106,6 +151,20 @@ export function TemplateDialog({
 
   const targets = { groups, hosts };
 
+  const updateValue = (name: string, value: unknown) => {
+    setValues((current) => ({ ...current, [name]: value }));
+    setFieldErrors((current) => Object.fromEntries(
+      Object.entries(current).filter(([field]) => (
+        field !== name && !field.startsWith(`${name}.`) && !field.startsWith(`${name}[`)
+      )),
+    ));
+  };
+
+  const handleTemplateError = (error: unknown) => {
+    setFieldErrors(templateFieldErrors(error));
+    toast.error(error instanceof Error ? error.message : "Template request failed");
+  };
+
   const shouldRefreshRenderedYaml = (candidate: string) => templateId === "k8s-cluster" && (
     !candidate.includes("# OpenSible k8s template generation: 2026-07-cgroup-fix-v7") ||
     candidate.includes("Wait for first control-plane apiserver to be reachable") ||
@@ -131,7 +190,8 @@ export function TemplateDialog({
       );
       setYaml(res.yaml);
       setFilename((current) => current || res.filename);
-    } catch (e) { toast.error((e as Error).message); }
+      setFieldErrors({});
+    } catch (e) { handleTemplateError(e); }
     finally { setBusy(null); }
   };
 
@@ -160,8 +220,9 @@ export function TemplateDialog({
 
       const extra = res.written && res.written.length > 1 ? ` (+${res.written.length - 1} sidecar files)` : "";
       toast.success(`Saved ${res.filename}${extra}`);
+      setFieldErrors({});
       if (cicdEnabled) await syncCicdPipeline(res.filename, false);
-    } catch (e) { toast.error((e as Error).message); }
+    } catch (e) { handleTemplateError(e); }
     finally { setBusy(null); }
   };
 
@@ -240,7 +301,8 @@ export function TemplateDialog({
         toast.success("Run queued");
       }
       if (cicdEnabled) await syncCicdPipeline(saved.filename, false);
-    } catch (e) { toast.error((e as Error).message); }
+      setFieldErrors({});
+    } catch (e) { handleTemplateError(e); }
     finally { setBusy(null); }
   };
 
@@ -249,7 +311,7 @@ export function TemplateDialog({
     catch { toast.error("Copy failed"); }
   };
 
-  const updateNodes = (name: string, rows: NodeRow[]) => setValues({ ...values, [name]: rows });
+  const updateNodes = (name: string, rows: NodeRow[]) => updateValue(name, rows);
 
   return (
     <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4" onClick={onClose}>
@@ -316,7 +378,7 @@ export function TemplateDialog({
                       <input
                         type="checkbox"
                         checked={!!values[v.name]}
-                        onChange={(e) => setValues({ ...values, [v.name]: e.target.checked })}
+                        onChange={(e) => updateValue(v.name, e.target.checked)}
                       />
                       Enable
                     </label>
@@ -325,7 +387,7 @@ export function TemplateDialog({
                   <div className="mt-1 border border-[var(--color-border)] rounded-md overflow-hidden">
                     <YamlEditor
                       value={String(values[v.name] ?? "")}
-                      onChange={(nv) => setValues({ ...values, [v.name]: nv })}
+                      onChange={(nv) => updateValue(v.name, nv)}
                       height={(v.rows || 8) * 20}
                     />
                   </div>
@@ -335,7 +397,7 @@ export function TemplateDialog({
                     className="mt-1"
                     value={String(values[v.name] ?? "")}
                     onChange={(e) =>
-                      setValues({ ...values, [v.name]: e.target.value ? Number(e.target.value) : "" })
+                      updateValue(v.name, e.target.value ? Number(e.target.value) : "")
                     }
                   />
                 ) : v.type === "nodes" ? (
@@ -353,9 +415,10 @@ export function TemplateDialog({
                     className="mt-1"
                     placeholder={v.placeholder}
                     value={String(values[v.name] ?? "")}
-                    onChange={(e) => setValues({ ...values, [v.name]: e.target.value })}
+                    onChange={(e) => updateValue(v.name, e.target.value)}
                   />
                 )}
+                <TemplateValidationMessages name={v.name} fieldErrors={fieldErrors} />
                 {v.help && (
                   <div className="text-[11px] text-[var(--color-muted-foreground)] mt-1">{v.help}</div>
                 )}
@@ -582,7 +645,10 @@ export function TemplateDialog({
           path={historyPath}
           onClose={() => setHistoryPath(null)}
           onRestore={(v, t) => {
-            if (v && typeof v === "object") setValues(v as Record<string, unknown>);
+            if (v && typeof v === "object") {
+              setValues(v as Record<string, unknown>);
+              setFieldErrors({});
+            }
             const tt = (t || {}) as { groups?: string[]; hosts?: string[] };
             if (Array.isArray(tt.groups)) setGroups(tt.groups);
             if (Array.isArray(tt.hosts)) setHosts(tt.hosts);

--- a/server/api/templates_routes.py
+++ b/server/api/templates_routes.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional
 
 from flask import Blueprint, jsonify, request
 
-from templates import list_templates, get_template, render_template
+from templates import TemplateValidationError, list_templates, get_template, render_template
 
 logger = logging.getLogger(__name__)
 bp = Blueprint("templates_api", __name__, url_prefix="/api/templates")
@@ -280,6 +280,8 @@ def render(template_id: str):
     targets = body.get("targets") or {}
     try:
         return jsonify(render_template(template_id, values, targets))
+    except TemplateValidationError as e:
+        return jsonify({"error": str(e), "field_errors": e.field_errors}), 400
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
     except Exception as e:
@@ -304,6 +306,8 @@ def save(template_id: str):
 
     try:
         result = render_template(template_id, values, targets)
+    except TemplateValidationError as e:
+        return jsonify({"error": str(e), "field_errors": e.field_errors}), 400
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
 

--- a/server/templates/__init__.py
+++ b/server/templates/__init__.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from .validation import TemplateValidationError
+
 from . import docker_compose as _docker_compose
 from . import nginx_reverse_proxy as _nginx_rp
 from . import k3s_bootstrap as _k3s

--- a/server/templates/k8s_cluster.py
+++ b/server/templates/k8s_cluster.py
@@ -15,15 +15,25 @@ Renders:
 """
 from __future__ import annotations
 
+import ipaddress
+import re
+from collections.abc import Mapping
 from typing import Any, Dict, List
 
 from ._common import (  # noqa: F401
     slugify, yaml_str, render_hosts,
     VAULT_FILES_VARIABLE, parse_vault_files, vars_files_lines,
 )
+from .validation import TemplateValidationError
 
 
 K8S_TEMPLATE_GENERATION = "2026-07-metrics-tls-v10"
+
+_KUBERNETES_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+$")
+_ENDPOINT_HOST_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$")
+_ALLOWED_CNI = {"calico", "flannel", "none"}
+_ALLOWED_KUBE_PROXY_MODES = {"iptables", "ipvs", "none"}
+_ALLOWED_STORAGE = {"none", "longhorn", "local-path", "openebs-hostpath", "nfs-subdir"}
 
 
 TEMPLATE = {
@@ -150,6 +160,133 @@ def _norm_nodes(raw: Any, default_user: str, default_port: Any) -> List[Dict[str
     return out
 
 
+def _add_error(errors: Dict[str, List[str]], field: str, message: str) -> None:
+    errors.setdefault(field, []).append(message)
+
+
+def _string_value(values: Dict[str, Any], field: str, default: str) -> str:
+    raw = values.get(field)
+    return str(default if raw is None or raw == "" else raw).strip()
+
+
+def _validate_port(errors: Dict[str, List[str]], field: str, raw: Any) -> None:
+    if raw is None or raw == "":
+        return
+    if isinstance(raw, bool):
+        _add_error(errors, field, "must be an integer from 1 to 65535")
+        return
+    try:
+        port = int(raw)
+    except (TypeError, ValueError):
+        _add_error(errors, field, "must be an integer from 1 to 65535")
+        return
+    if not 1 <= port <= 65535:
+        _add_error(errors, field, "must be an integer from 1 to 65535")
+
+
+def _validate_nodes(errors: Dict[str, List[str]], values: Dict[str, Any]) -> None:
+    seen_addresses: Dict[str, str] = {}
+    seen_names: Dict[str, str] = {}
+    default_port = values.get("ssh_port_default", 22)
+    _validate_port(errors, "ssh_port_default", default_port)
+
+    for field, required in (("control_planes", True), ("workers", False)):
+        raw_nodes = values.get(field, [] if not required else None)
+        if not isinstance(raw_nodes, list):
+            _add_error(errors, field, "must be a list of node mappings")
+            continue
+        if required and not raw_nodes:
+            _add_error(errors, field, "must contain at least one node")
+        for index, raw_node in enumerate(raw_nodes):
+            item_field = f"{field}[{index}]"
+            if not isinstance(raw_node, Mapping):
+                _add_error(errors, item_field, "must be a node mapping")
+                continue
+            address = str(raw_node.get("ip") or "").strip()
+            if not address:
+                _add_error(errors, f"{item_field}.ip", "is required")
+            else:
+                address_key = address.lower()
+                if address_key in seen_addresses:
+                    _add_error(errors, f"{item_field}.ip", f"duplicates {seen_addresses[address_key]}")
+                else:
+                    seen_addresses[address_key] = f"{item_field}.ip"
+
+            _validate_port(errors, f"{item_field}.ssh_port", raw_node.get("ssh_port"))
+            name = str(raw_node.get("name") or f"node-{index + 1}").strip()
+            normalized_name = slugify(name, f"node-{index + 1}")[:63].strip("-") or f"node-{index + 1}"
+            if normalized_name in seen_names:
+                _add_error(errors, f"{item_field}.name", f"normalizes to duplicate Kubernetes node name {normalized_name!r}")
+            else:
+                seen_names[normalized_name] = f"{item_field}.name"
+
+
+def _validate_values(values: Dict[str, Any]) -> None:
+    """Raise structured errors before interpolating kubeadm configuration."""
+    if not isinstance(values, dict):
+        raise TemplateValidationError({"values": "must be an object"})
+
+    errors: Dict[str, List[str]] = {}
+    version = _string_value(values, "kubernetes_version", "1.30.4")
+    if not _KUBERNETES_VERSION_RE.fullmatch(version):
+        _add_error(errors, "kubernetes_version", "must be a full version such as 1.30.4")
+
+    networks: Dict[str, ipaddress.IPv4Network] = {}
+    for field, default in (("pod_cidr", "10.244.0.0/16"), ("service_cidr", "10.96.0.0/12")):
+        raw = _string_value(values, field, default)
+        try:
+            network = ipaddress.ip_network(raw, strict=True)
+        except ValueError:
+            _add_error(errors, field, "must be a strict IPv4 network CIDR")
+            continue
+        if not isinstance(network, ipaddress.IPv4Network):
+            _add_error(errors, field, "must be a strict IPv4 network CIDR")
+            continue
+        networks[field] = network
+    if len(networks) == 2 and networks["pod_cidr"].overlaps(networks["service_cidr"]):
+        _add_error(errors, "pod_cidr", "must not overlap service_cidr")
+        _add_error(errors, "service_cidr", "must not overlap pod_cidr")
+
+    cni = _string_value(values, "cni_plugin", "calico").lower()
+    if cni not in _ALLOWED_CNI:
+        _add_error(errors, "cni_plugin", "must be one of: calico, flannel, none")
+    elif cni == "flannel" and networks.get("pod_cidr") != ipaddress.IPv4Network("10.244.0.0/16"):
+        _add_error(errors, "pod_cidr", "must be 10.244.0.0/16 when cni_plugin is flannel")
+
+    kube_proxy_mode = _string_value(values, "kube_proxy_mode", "iptables").lower()
+    if kube_proxy_mode not in _ALLOWED_KUBE_PROXY_MODES:
+        _add_error(errors, "kube_proxy_mode", "must be one of: iptables, ipvs, none")
+    elif kube_proxy_mode == "none" and cni != "none":
+        _add_error(errors, "kube_proxy_mode", "none requires cni_plugin to be none")
+
+    runtime = _string_value(values, "container_runtime", "containerd").lower()
+    if runtime != "containerd":
+        _add_error(errors, "container_runtime", "must be containerd")
+
+    storage = _string_value(values, "storage_provisioner", "none").lower()
+    if storage not in _ALLOWED_STORAGE:
+        _add_error(errors, "storage_provisioner", "must be one of: none, longhorn, local-path, openebs-hostpath, nfs-subdir")
+    elif storage == "nfs-subdir":
+        if not _string_value(values, "nfs_server", ""):
+            _add_error(errors, "nfs_server", "is required when storage_provisioner is nfs-subdir")
+        raw_nfs_path = values.get("nfs_path")
+        nfs_path = "/srv/nfs/k8s" if raw_nfs_path is None else str(raw_nfs_path).strip()
+        if not nfs_path.startswith("/"):
+            _add_error(errors, "nfs_path", "must be an absolute path when storage_provisioner is nfs-subdir")
+
+    endpoint = _string_value(values, "control_plane_endpoint", "")
+    if endpoint:
+        host, separator, port_text = endpoint.rpartition(":")
+        if not separator or not _ENDPOINT_HOST_RE.fullmatch(host) or ":" in host:
+            _add_error(errors, "control_plane_endpoint", "must use host:port syntax")
+        else:
+            _validate_port(errors, "control_plane_endpoint", port_text)
+
+    _validate_nodes(errors, values)
+    if errors:
+        raise TemplateValidationError(errors)
+
+
 def _inventory_yaml(cluster: str, cps: List[Dict[str, Any]], workers: List[Dict[str, Any]]) -> str:
     cp_group = f"{cluster}_control_plane"
     wk_group = f"{cluster}_workers"
@@ -181,6 +318,7 @@ def _inventory_yaml(cluster: str, cps: List[Dict[str, Any]], workers: List[Dict[
 
 
 def render(values: Dict[str, Any], targets: Dict[str, Any]) -> str:
+    _validate_values(values)
     cluster = slugify(values.get("cluster_name") or "cluster", "cluster")
     cp_group = f"{cluster}_control_plane"
     wk_group = f"{cluster}_workers"
@@ -192,9 +330,9 @@ def render(values: Dict[str, Any], targets: Dict[str, Any]) -> str:
     become = "true" if values.get("become", True) else "false"
     ha_mode = bool(values.get("ha_mode"))
     cp_endpoint = str(values.get("control_plane_endpoint") or "").strip()
-    pod_cidr = values.get("pod_cidr") or "10.244.0.0/16"
-    service_cidr = values.get("service_cidr") or "10.96.0.0/12"
-    cni = (values.get("cni_plugin") or "calico").lower()
+    pod_cidr = _string_value(values, "pod_cidr", "10.244.0.0/16")
+    service_cidr = _string_value(values, "service_cidr", "10.96.0.0/12")
+    cni = _string_value(values, "cni_plugin", "calico").lower()
     reset_existing = bool(values.get("reset_existing_cluster", False))
     install_metrics = bool(values.get("install_metrics_server", True))
     storage = str(values.get("storage_provisioner") or "none").lower().strip()
@@ -208,19 +346,7 @@ def render(values: Dict[str, Any], targets: Dict[str, Any]) -> str:
     nfs_path = str(values.get("nfs_path") or "/srv/nfs/k8s").strip()
     allow_cp_sched = bool(values.get("allow_scheduling_on_control_plane", False))
     fetch_kubeconfig = bool(values.get("fetch_kubeconfig", True))
-    kube_proxy_mode = str(values.get("kube_proxy_mode") or "iptables").lower().strip()
-    if kube_proxy_mode not in ("iptables", "ipvs", "none"):
-        kube_proxy_mode = "iptables"
-    requested_kube_proxy_mode = kube_proxy_mode
-    # Calico/Flannel do not replace Kubernetes Service routing by default. If
-    # kube-proxy is skipped, calico-node's install-cni init container commonly
-    # cannot reach the apiserver Service (10.96.0.1), leaving every node
-    # NotReady with "CNI plugin not initialized". Treat "none" as IPVS for
-    # built-in Calico/Flannel so users can avoid iptables mode without breaking
-    # the cluster. True kube-proxy-less mode remains available with CNI=None for
-    # users who install Cilium/Calico eBPF manually.
-    if kube_proxy_mode == "none" and cni in ("calico", "flannel"):
-        kube_proxy_mode = "ipvs"
+    kube_proxy_mode = _string_value(values, "kube_proxy_mode", "iptables").lower()
 
     cps = _norm_nodes(values.get("control_planes"),
                       values.get("ssh_user_default") or "root",
@@ -237,10 +363,7 @@ def render(values: Dict[str, Any], targets: Dict[str, Any]) -> str:
     parts.append(f"# OpenSible k8s template generation: {K8S_TEMPLATE_GENERATION}")
     parts.append(f"# Cluster: {cluster} (HA={ha_mode}, control-plane={len(cps)}, workers={len(workers)})")
     parts.append(f"# Kubernetes: v{version} | CNI: {cni} | Pod CIDR: {pod_cidr}")
-    if requested_kube_proxy_mode != kube_proxy_mode:
-        parts.append(f"# kube-proxy: requested {requested_kube_proxy_mode}, using {kube_proxy_mode} because {cni} does not replace Service routing by default")
-    else:
-        parts.append(f"# kube-proxy: {kube_proxy_mode}")
+    parts.append(f"# kube-proxy: {kube_proxy_mode}")
     parts.append(f"# Inventory sidecar: inventories/{cluster}.yml")
     parts.append("")
 

--- a/server/templates/validation.py
+++ b/server/templates/validation.py
@@ -1,0 +1,18 @@
+"""Structured validation errors raised by deployment templates."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+class TemplateValidationError(ValueError):
+    """Validation failure that callers can associate with template fields."""
+
+    def __init__(self, field_errors: Mapping[str, str | Iterable[str]]):
+        normalized: dict[str, list[str]] = {}
+        for field, messages in field_errors.items():
+            items = [messages] if isinstance(messages, str) else list(messages)
+            clean = [str(message) for message in items if str(message).strip()]
+            if clean:
+                normalized[str(field)] = clean
+        self.field_errors = normalized
+        super().__init__("validation failed")

--- a/server/tests/test_k8s_cluster_template.py
+++ b/server/tests/test_k8s_cluster_template.py
@@ -1,0 +1,126 @@
+"""Contract tests for the kubeadm template renderer validation boundary."""
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+import yaml
+from flask import Flask
+
+from api.templates_routes import bp as templates_bp
+from templates import render_template
+
+
+BASE_VALUES = {
+    "cluster_name": "validation-cluster",
+    "kubernetes_version": "1.30.4",
+    "pod_cidr": "10.244.0.0/16",
+    "service_cidr": "10.96.0.0/12",
+    "cni_plugin": "calico",
+    "container_runtime": "containerd",
+    "kube_proxy_mode": "iptables",
+    "storage_provisioner": "none",
+    "control_planes": [{"name": "cp-1", "ip": "10.0.0.10", "ssh_port": 22}],
+    "workers": [{"name": "worker-1", "ip": "worker-1.internal", "ssh_port": 22}],
+}
+
+
+def render_values(**overrides):
+    values = deepcopy(BASE_VALUES)
+    values.update(overrides)
+    return render_template("k8s-cluster", values, {})
+
+
+@pytest.fixture
+def templates_client():
+    app = Flask(__name__)
+    app.register_blueprint(templates_bp)
+    return app.test_client()
+
+
+def test_render_accepts_valid_custom_calico_configuration():
+    result = render_values(
+        kubernetes_version="v1.29.7",
+        pod_cidr="10.200.0.0/16",
+        service_cidr="10.100.0.0/16",
+        kube_proxy_mode="ipvs",
+        control_plane_endpoint="api.k8s.example:6443",
+        ha_mode=True,
+        control_planes=[
+            {"name": "cp-1", "ip": "10.0.0.10", "ssh_port": 22},
+            {"name": "cp-2", "ip": "10.0.0.11", "ssh_port": 22},
+        ],
+        storage_provisioner="nfs-subdir",
+        nfs_server="nfs.internal.example",
+        nfs_path="/srv/nfs/k8s",
+    )
+
+    assert isinstance(yaml.safe_load(result["yaml"]), list)
+    assert "--kubernetes-version=v1.29.7" in result["yaml"]
+    assert "--pod-network-cidr=10.200.0.0/16" in result["yaml"]
+    assert "--service-cidr=10.100.0.0/16" in result["yaml"]
+    assert "api.k8s.example:6443" in result["yaml"]
+    assert result["sidecars"]["inventories/validation-cluster.yml"]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "field"),
+    [
+        ({"kubernetes_version": "1.30"}, "kubernetes_version"),
+        ({"kubernetes_version": "1.30.4; echo unsafe"}, "kubernetes_version"),
+        ({"pod_cidr": "not-a-cidr"}, "pod_cidr"),
+        ({"pod_cidr": "10.244.1.1/16"}, "pod_cidr"),
+        ({"pod_cidr": "fd00::/64"}, "pod_cidr"),
+        ({"pod_cidr": "10.96.0.0/16", "service_cidr": "10.96.0.0/12"}, "pod_cidr"),
+        ({"cni_plugin": "flannel", "pod_cidr": "10.200.0.0/16"}, "pod_cidr"),
+        ({"cni_plugin": "cilium"}, "cni_plugin"),
+        ({"kube_proxy_mode": "unknown"}, "kube_proxy_mode"),
+        ({"kube_proxy_mode": "none"}, "kube_proxy_mode"),
+        ({"container_runtime": "docker"}, "container_runtime"),
+        ({"storage_provisioner": "nfs"}, "storage_provisioner"),
+        ({"storage_provisioner": "nfs-subdir", "nfs_server": ""}, "nfs_server"),
+        ({"storage_provisioner": "nfs-subdir", "nfs_server": "nfs.example", "nfs_path": ""}, "nfs_path"),
+        ({"storage_provisioner": "nfs-subdir", "nfs_server": "nfs.example", "nfs_path": "relative/path"}, "nfs_path"),
+        ({"control_plane_endpoint": "api.k8s.example"}, "control_plane_endpoint"),
+        ({"control_plane_endpoint": "api.k8s.example:70000"}, "control_plane_endpoint"),
+    ],
+)
+def test_render_rejects_invalid_scalar_configuration_with_field_errors(overrides, field):
+    with pytest.raises(ValueError) as exc_info:
+        render_values(**overrides)
+
+    assert field in exc_info.value.field_errors
+
+
+@pytest.mark.parametrize(
+    ("overrides", "field"),
+    [
+        ({"control_planes": []}, "control_planes"),
+        ({"control_planes": "10.0.0.10"}, "control_planes"),
+        ({"control_planes": [{"name": "cp-1", "ip": ""}]}, "control_planes[0].ip"),
+        ({"control_planes": [{"name": "cp-1", "ip": "10.0.0.10", "ssh_port": 0}]}, "control_planes[0].ssh_port"),
+        ({"control_planes": [{"name": "cp-1", "ip": "10.0.0.10"}], "workers": [{"name": "worker-1", "ip": "10.0.0.10"}]}, "workers[0].ip"),
+        ({"control_planes": [{"name": "cp-1", "ip": "cp.internal"}], "workers": [{"name": "worker-1", "ip": "CP.INTERNAL"}]}, "workers[0].ip"),
+        ({"control_planes": [{"name": "CP One", "ip": "10.0.0.10"}], "workers": [{"name": "cp-one", "ip": "10.0.0.20"}]}, "workers[0].name"),
+    ],
+)
+def test_render_rejects_invalid_node_topology_with_field_errors(overrides, field):
+    with pytest.raises(ValueError) as exc_info:
+        render_values(**overrides)
+
+    assert field in exc_info.value.field_errors
+
+
+def test_render_endpoint_returns_structured_field_errors(templates_client):
+    response = templates_client.post(
+        "/api/templates/k8s-cluster/render",
+        json={"values": {**BASE_VALUES, "kubernetes_version": "1.30"}, "targets": {}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "validation failed",
+        "field_errors": {
+            "kubernetes_version": ["must be a full version such as 1.30.4"],
+        },
+    }


### PR DESCRIPTION
## Description

Fixes #32

The live `k8s-cluster` renderer previously generated playbooks before enforcing its public configuration contract. Unsupported values could therefore produce incomplete playbooks, `kube_proxy_mode: none` with Calico or Flannel was silently changed to IPVS, and Flannel accepted a custom pod CIDR even though its applied manifest uses `10.244.0.0/16`.

This PR:

- validates full Kubernetes patch versions, strict non-overlapping IPv4 CIDRs, supported CNI/runtime/kube-proxy/storage values, node topology, NFS fields, and optional `host:port` control-plane endpoints before generation;
- returns structured field-level `400` errors from render/save and displays them inline in the console;
- rejects incompatible Flannel CIDRs and kube-proxy combinations instead of mutating them silently; and
- aligns the kubeadm README, metadata defaults, and example variables with the live renderer contract.

Valid existing configurations retain their current rendering behavior. Configurations that were accepted but could not produce the requested cluster now fail early with actionable field errors. The checked-in static `playbook.yml` is documented as a fixed generated example and is otherwise unchanged.

No new CNI, storage backend, manifest pinning, IPv6/dual-stack behavior, or renderer refactor is included.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Components affected

- [x] Backend (`server/`)
- [ ] Worker (`worker/`)
- [x] Frontend (`console/`)
- [x] IaC blueprints (`IaC/`)
- [ ] Docker / deployment (`docker-compose*.yml`, `Dockerfile`, `docker/`)

## How has this been tested?

- [x] Unit tests: full server suite, 52 passed (`pytest -q`)
- [x] Manual verification: valid non-default render parsed as YAML and contained the requested version, CIDRs, endpoint, and inventory sidecar
- [ ] `ansible-lint` / `tofu validate` for IaC changes (the static playbook is unchanged)
- [x] Console TypeScript compile (`bunx tsc --noEmit`)
- [x] Console production build (`bun run build`)
- [x] Worker regression check (`go test ./...`)
- [x] Blueprint metadata, example variables, and static playbook parsed with `yaml.safe_load_all`
- [x] `git diff --check`

## Screenshots / logs

Validation responses use a stable field-level shape that the console renders below the matching input:

```json
{
  "error": "validation failed",
  "field_errors": {
    "kubernetes_version": ["must be a full version such as 1.30.4"]
  }
}
```

## Checklist

- [x] I have read the `CONTRIBUTING.md` guide.
- [x] My code follows the project's coding standards and passes the available type and whitespace checks.
- [x] I have added tests that prove the fix is effective.
- [x] I have updated documentation where relevant.
- [x] Changelog entry is not applicable because this repository has no `CHANGELOG.md`.
- [x] No secrets, credentials, or PII are committed.
- [x] No migration is required; the intentional compatibility tightening is documented above.
